### PR TITLE
flag to turn off automatic save on end of session

### DIFF
--- a/lib/alexa.js
+++ b/lib/alexa.js
@@ -55,6 +55,11 @@ function alexaRequestHandler(event, context, callback) {
         writable: true
     });
 
+    Object.defineProperty(handler, 'saveOnEndSession', {
+        value: true,
+        writable: true
+    });
+
     Object.defineProperty(handler, 'saveBeforeResponse', {
         value: false,
         writable: true

--- a/lib/response.js
+++ b/lib/response.js
@@ -109,7 +109,7 @@ module.exports = (function () {
                 this.attributes['STATE'] = this.handler.state;
             }
 
-            if(this.saveBeforeResponse || forceSave || this.handler.response.response.shouldEndSession) {
+            if(this.saveBeforeResponse || forceSave || (this.saveOnEndSession && this.handler.response.response.shouldEndSession)) {
                 attributesHelper.set(this.handler.dynamoDBTableName, this.event.session.user.userId, this.attributes,
                     (err) => {
                         if(err) {


### PR DESCRIPTION
The default value make it so there is no behavior change.

saveState is emitted every time there is a response. Normally it won't
save unless saveOnResponse is true, but any kind of tell request by
definition also has shouldEndSession true, and will therefore save to
database. We might not want that, so this flag allows you to control
whether or not save is called in the case of shouldEndSession.