### PR TITLE
Making a .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
While a global .gitignore makes sense for developer specific stuff (e.g. .DS_STORE), they do not for files that are common for everyone using the project but you specifically don't want versioned (e.g. node_modules). Adding a .gitignore to cover these files.
