### PR TITLE
Correctly save STATE for empty strings

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -90,7 +90,7 @@ module.exports = (function () {
                 return;
             }
 
-            if(this.handler.state) {
+            if(typeof this.handler.state === 'string') {
                 this.handler.response.sessionAttributes['STATE'] = this.handler.state;
             }
 
@@ -105,7 +105,7 @@ module.exports = (function () {
                 return;
             }
 
-            if(forceSave && this.handler.state){
+            if(forceSave && typeof this.handler.state === 'string'){
                 this.attributes['STATE'] = this.handler.state;
             }
 


### PR DESCRIPTION
Currently the state does not save correctly when `this.handler.state` is an empty string because `''` is falsy in JS. This currently occurs when emitting `this.emit(':responseReady')` as well as `this.emit(':saveState', true)`.

This fixes the issue by checking if `this.handler.state` is a string.