### PR TITLE
allow SSML content in options.output

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -146,7 +146,7 @@ module.exports = (function () {
     };
 })();
 
-function createSpeechObject(optionsParam) {
+function getSSMLResponse(optionsParam) {
     if (optionsParam && optionsParam.type === 'SSML') {
         return {
             type: optionsParam.type,
@@ -162,13 +162,13 @@ function createSpeechObject(optionsParam) {
 
 function buildSpeechletResponse(options) {
     var alexaResponse = {
-        outputSpeech: createSpeechObject(options.output),
+        outputSpeech: options.output,
         shouldEndSession: options.shouldEndSession
     };
 
     if (options.reprompt) {
         alexaResponse.reprompt = {
-            outputSpeech: createSpeechObject(options.reprompt)
+            outputSpeech: options.reprompt
         };
     }
 
@@ -209,12 +209,4 @@ function buildSpeechletResponse(options) {
         returnResult.sessionAttributes = options.sessionAttributes;
     }
     return returnResult;
-}
-
-// TODO: check for ssml content in card
-function getSSMLResponse(message) {
-    return {
-        type: 'SSML',
-        speech: `<speak> ${message} </speak>`
-    };
 }


### PR DESCRIPTION
Hi, 

yesterday I learned that it is not possible to use SSML in the alexa sdk, but it is possible with this small fix. No breaking changes. 

Example: 

``` js
var speechOutput = {
  "type": "SSML",
  "speech": '<speak><say-as interpret-as="cardinal">' + amount + '</say-as> ' + spoken_from + ' are converted to <say-as interpret-as="unit">' + value + "</say-as> " + spoken_to + " </speak>"
};
this.emit(':tellWithCard', speechOutput, SKILL_NAME)
```

This is also be possible as before: 

``` js
this.emit(':tellWithCard', "Sorry, try again.", SKILL_NAME)
```
