### PR TITLE
Add support for Unhandled events when using EmitWithState.

### DIFF
--- a/lib/alexa.js
+++ b/lib/alexa.js
@@ -396,6 +396,15 @@ function EmitWithState() {
         throw new Error('EmitWithState called without arguments');
     }
     arguments[0] = arguments[0] + this.state;
+
+    if (this.listenerCount(arguments[0]) < 1) {
+        arguments[0] = 'Unhandled' + this.state;
+    }
+
+    if (this.listenerCount(arguments[0]) < 1) {
+        throw new Error(`No 'Unhandled' function defined for event: ${arguments[0]}`);
+    }
+
     this.emit.apply(this, arguments);
 }
 


### PR DESCRIPTION
Previously, if EmitWithState was used to call an event that was not declared in that state, an error would be thrown. This is in contrast to the behavior of EmitEvent, in which these events would be routed to the 'Unhandled_<state>' event. 

This change will cause EmitWithState to call an appropriate 'Unhandled_<state>' event when necessary, or throw an error if the 'Unhandled_<state>' event is needed but does not exist.