### PR TITLE
Adding slots to the handlerContext

### DIFF
--- a/lib/alexa.js
+++ b/lib/alexa.js
@@ -233,6 +233,7 @@ function RegisterHandlers() {
                 t : localize,
                 event: this._event,
                 attributes: this._event.session.attributes,
+                slots: this._event.request.intent.slots,
                 context: this._context,
                 name: eventName,
                 isOverridden:  IsOverridden.bind(this, eventName),


### PR DESCRIPTION
It was very hard for me to find out how to use the slots. This took a lot of looking around. One of the issues being that the examples I saw that used the slots, defined there own ways of handling the requests (eg. Reindeer Games). 

This would be useful for others to access more easily.

enables using
```
var date = this.slots.Date.value;
```

instead of always using 
```
var date = this.event.request.intent.slots.Date.value;
```