### PR TITLE
Add Tracking with Amazon Mobile Analytics

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -259,6 +259,51 @@ this.attributes['yourAttribute'] = 'value';
 
 You can [create the table manually](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/SampleData.CreateTables.html) beforehand or simply give your Lambda function DynamoDB [create table permissions](http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CreateTable.html) and it will happen automatically. Just remember it can take a minute or so for the table to be created on the first invocation.
 
+### Tracking Usage with Amazon Mobile Analytics
+
+Wouldn't it be nice if you could track all LaunchRequest, IntentRequest, and SessionEndedRequest request types in [Amazon Mobile Analytics](https://aws.amazon.com/mobileanalytics/) with a single setting?
+
+Simply set the mobile analytics settings on your alexa object before you call alexa.execute. These settings include the skill name as well as the application id created in Mobile Analytics:
+```javascript
+exports.handler = function (event, context, callback) {
+    var alexa = Alexa.handler(event, context);
+    alexa.appId = appId;
+    
+    // That's it!
+    alexa.mobileAnalyticsSettings = {
+        appId: 'b2a5.....', 
+        appTitle: 'MY SKILL NAME' 
+    };
+
+    alexa.registerHandlers(State1Handlers, State2Handlers);
+    alexa.execute();
+};
+```
+
+How about a custom event in a handler function? Call **this.recordMobileAnalyticsEvent**:
+
+```javascript
+'GetFact': function () {
+    var attributes = {},
+        metrics = {};
+
+    this.recordMobileAnalyticsEvent('CustomEvent', this.event.session.sessionId, attributes, metrics, (err, data) => {
+
+        // Get a random space fact from the space facts list
+        // Use this.t() to get corresponding language data
+        var factArr = this.t('FACTS');
+        var factIndex = Math.floor(Math.random() * factArr.length);
+        var randomFact = factArr[factIndex];
+
+        // Create speech output
+        var speechOutput = this.t("GET_FACT_MESSAGE") + randomFact;
+        this.emit(':tellWithCard', speechOutput, this.t("SKILL_NAME"), randomFact)
+    });    
+},  
+```
+Use the IAM console and add the **AmazonMobileAnalyticsWriteOnlyAccess** policy to the Role associated with the Lambda function for your skill.
+
+
 ### Next Steps
 
 Try extending the HighLow game:

--- a/lib/MobileAnalyticsHelper.js
+++ b/lib/MobileAnalyticsHelper.js
@@ -1,55 +1,61 @@
 'use strict';
 var aws = require('aws-sdk');
-var mobileanalytics;
+var ma;
 
-module.exports = function MobileAnalyticsHelper(options) {
-    this.options = options || {};
+module.exports = function MobileAnalyticsHelper() {
 
-    if (options.appId === undefined) {
-        console.log('Mobile Analytics ApplicationId must be set.');
-        return null; //No need to run rest of init since appId is required
-    }
+    this._init = function(options) {
+        this.options = options || {};
 
-    this.options.apiVersion = this.options.apiVersion || '2014-06-05';
-    this.options.platform = this.options.platform || 'linux';
-    this.options.clientContext = this.options.clientContext || {
-        'client': {
-            'client_id': this.options.clientId,
-            'app_title': this.options.appTitle,
-            'app_version_name': this.options.appVersionName,
-            'app_version_code': this.options.appVersionCode,
-            'app_package_name': this.options.appPackageName
-        },
-        'env': {
-            'platform': this.options.platform,
-            'platform_version': this.options.platformVersion,
-            'model': this.options.model,
-            'make': this.options.make,
-            'locale': this.options.locale
-        },
-        'services': {
-            'mobile_analytics': {
-                'app_id': this.options.appId
-            }
-        },
-        'custom': {}
+        if (options.appId === undefined) {
+            console.log('Mobile Analytics ApplicationId must be set.');
+            return null; //No need to run rest of init since appId is required
+        }
+
+        this.options.apiVersion = this.options.apiVersion || '2014-06-05';
+        this.options.platform = this.options.platform || 'linux';
+        this.options.clientContext = this.options.clientContext || {
+            'client': {
+                'client_id': this.options.clientId,
+                'app_title': this.options.appTitle,
+                'app_version_name': this.options.appVersionName,
+                'app_version_code': this.options.appVersionCode,
+                'app_package_name': this.options.appPackageName
+            },
+            'env': {
+                'platform': this.options.platform,
+                'platform_version': this.options.platformVersion,
+                'model': this.options.model,
+                'make': this.options.make,
+                'locale': this.options.locale
+            },
+            'services': {
+                'mobile_analytics': {
+                    'app_id': this.options.appId
+                }
+            },
+            'custom': {}
+        };
+
+        if (!ma) {
+            ma = new aws.MobileAnalytics({ apiVersion: this.options.apiVersion });
+        }        
     };
 
-    if (!mobileanalytics) {
-        mobileanalytics = new aws.MobileAnalytics({ apiVersion: this.options.apiVersion });
-    }
 
-    this.startSession = function (sessionId) {
-        this.startTimestamp = new Date().toISOString();
-        this.recordEvent('_session.start', sessionId);
-    };
-
-    this.stopSession = function (sessionId) {
+    this._stopSession = function (sessionId, callback) {
+        console.log('Mobile Analytics - Stop Session: ' + sessionId);
         this.stopTimestamp = new Date().toISOString();
-        this.recordEvent('_session.stop', sessionId);
+
+        this.recordEvent('_session.stop', sessionId, null, null, (err, data) => {
+            if (callback) {
+                callback(err, data);
+            }
+        });        
     };
 
-    this.recordEvent = function (eventType, sessionId, attributes, metrics) {
+
+    this._createEvent = function(eventType, sessionId, attributes, metrics) {
         var event = {
             eventType: eventType,
             timestamp: new Date().toISOString(),
@@ -67,24 +73,104 @@ module.exports = function MobileAnalyticsHelper(options) {
 
         if (this.stopTimestamp) {
             event.session.stopTimestamp = this.stopTimestamp;
-            event.session.duration = new Date(event.stopTimestamp).getTime() - new Date(event.startTimestamp).getTime();            
+            event.session.duration = new Date(this.stopTimestamp).getTime() - new Date(this.startTimestamp).getTime();            
         }
 
+        console.log('Mobile Analytics - Create Event: ' + eventType + ', ' + sessionId);
 
-        var params = {
-            clientContext: JSON.stringify(this.options.clientContext),
-            events: [event]
-        };
-
-        mobileanalytics.putEvents(params, function (err, data) {
-            if (err) {
-                console.log('Error during MobileAnalytics putEvents:' + err);
-            }
-            else {
-                console.log('Successful MobileAnalytics putEvents.');
-            }
-        })        
-
+        return event;
     };
 
+
+    this._recordRequest = function (event, callback) {
+
+        var eventType = event.request.type;
+        var isNewSession =  event.session['new'];
+        var events = [];
+            
+        if (event.session.sessionId && isNewSession) {
+
+            console.log('Mobile Analytics - Start Session: ' + event.session.sessionId);
+
+            this.startTimestamp = new Date().toISOString();
+            
+            // Create event for session start
+            var sessionStartEvent = this._createEvent('_session.start', event.session.sessionId);
+            events.push(sessionStartEvent);
+        }
+        else {
+
+            console.log('Mobile Analytics - Continue Session: ' + event.session.sessionId);
+
+            if (event.session.attributes.sessionStartTimestamp) {
+                this.startTimestamp = event.session.attributes.sessionStartTimestamp;
+            }
+        }
+
+        // Create event for eventType
+        var maAttributes = {};            
+
+        // If event is an intent, use intent name as eventType and add slots to attributes
+        if (event.request.intent) {
+            eventType = event.request.intent.name;
+            maAttributes.NewSession = isNewSession.toString();
+        
+            if (event.request.intent.slots != undefined) {
+                for (var key in event.request.intent.slots) {
+                    if (event.request.intent.slots.hasOwnProperty(key)) {
+                        var name = event.request.intent.slots[key].name;
+                        maAttributes[name] = event.request.intent.slots[key].value;
+                    }
+                }
+            }
+        }
+
+        var customEvent = this._createEvent(eventType, event.session.sessionId, maAttributes); 
+        events.push(customEvent);
+
+        this._recordEvents(events, (err, data) => {
+            if (callback) {
+                callback(err, data);
+            }            
+        });
+    };    
+
+
+    this._recordEvents = function (events, callback) {
+        var params = {
+            clientContext: JSON.stringify(this.options.clientContext),
+            events: events
+        };
+
+        ma.putEvents(params, (err, data) => {
+            if (err) {
+                console.log('Mobile Analytics - Error on putEvents:' + err);
+
+                if (callback) {
+                    callback(err, {});
+                }
+                
+            }
+            else {
+                console.log('Mobile Analytics - Successful putEvents.');
+                if (callback) {
+                    callback(null, {});
+                }
+            }
+        });    
+    };
+
+
+    this.recordEvent = function (eventType, sessionId, attributes, metrics, callback) {
+        var events = [];
+
+        var customEvent = this._createEvent(eventType, sessionId, attributes, metrics); 
+        events.push(customEvent);
+
+        this._recordEvents(events, (err, data) => {
+            if (callback) {
+                callback(err, data);
+            }  
+        });        
+    };
 };

--- a/lib/MobileAnalyticsHelper.js
+++ b/lib/MobileAnalyticsHelper.js
@@ -61,7 +61,7 @@ module.exports = function MobileAnalyticsHelper() {
             timestamp: new Date().toISOString(),
             attributes: attributes || {},
             session: {
-                'id': sessionId
+                'id': sessionId.substr(sessionId.length - 50)
             },
             version: 'v2.0',
             metrics: metrics || {}

--- a/lib/MobileAnalyticsHelper.js
+++ b/lib/MobileAnalyticsHelper.js
@@ -1,0 +1,90 @@
+'use strict';
+var aws = require('aws-sdk');
+var mobileanalytics;
+
+module.exports = function MobileAnalyticsHelper(options) {
+    this.options = options || {};
+
+    if (options.appId === undefined) {
+        console.log('Mobile Analytics ApplicationId must be set.');
+        return null; //No need to run rest of init since appId is required
+    }
+
+    this.options.apiVersion = this.options.apiVersion || '2014-06-05';
+    this.options.platform = this.options.platform || 'linux';
+    this.options.clientContext = this.options.clientContext || {
+        'client': {
+            'client_id': this.options.clientId,
+            'app_title': this.options.appTitle,
+            'app_version_name': this.options.appVersionName,
+            'app_version_code': this.options.appVersionCode,
+            'app_package_name': this.options.appPackageName
+        },
+        'env': {
+            'platform': this.options.platform,
+            'platform_version': this.options.platformVersion,
+            'model': this.options.model,
+            'make': this.options.make,
+            'locale': this.options.locale
+        },
+        'services': {
+            'mobile_analytics': {
+                'app_id': this.options.appId
+            }
+        },
+        'custom': {}
+    };
+
+    if (!mobileanalytics) {
+        mobileanalytics = new aws.MobileAnalytics({ apiVersion: this.options.apiVersion });
+    }
+
+    this.startSession = function (sessionId) {
+        this.startTimestamp = new Date().toISOString();
+        this.recordEvent('_session.start', sessionId);
+    };
+
+    this.stopSession = function (sessionId) {
+        this.stopTimestamp = new Date().toISOString();
+        this.recordEvent('_session.stop', sessionId);
+    };
+
+    this.recordEvent = function (eventType, sessionId, attributes, metrics) {
+        var event = {
+            eventType: eventType,
+            timestamp: new Date().toISOString(),
+            attributes: attributes || {},
+            session: {
+                'id': sessionId
+            },
+            version: 'v2.0',
+            metrics: metrics || {}
+        };
+
+        if (this.startTimestamp) {
+            event.session.startTimestamp = this.startTimestamp;
+        }
+
+        if (this.stopTimestamp) {
+            event.session.stopTimestamp = this.stopTimestamp;
+            event.session.duration = new Date(event.stopTimestamp).getTime() - new Date(event.startTimestamp).getTime();            
+        }
+
+
+        var params = {
+            clientContext: JSON.stringify(this.options.clientContext),
+            events: [event]
+        };
+
+        mobileanalytics.putEvents(params, function (err, data) {
+            if (err) {
+                console.log('Error during MobileAnalytics putEvents:' + err);
+            }
+            else {
+                console.log('Successful MobileAnalytics putEvents.');
+            }
+        })        
+
+    };
+
+};

--- a/lib/alexa.js
+++ b/lib/alexa.js
@@ -5,6 +5,7 @@ var util = require('util');
 var i18n = require('i18next');
 var sprintf = require('i18next-sprintf-postprocessor');
 var attributesHelper = require('./DynamoAttributesHelper');
+var mobileAnalyticsHelper = require('./MobileAnalyticsHelper');
 var responseHandlers = require('./response');
 var _StateString = 'STATE';
 
@@ -93,6 +94,16 @@ function alexaRequestHandler(event, context, callback) {
         writable: false
     });
 
+    Object.defineProperty(handler, 'mobileAnalyticsSettings', {
+        value: null,
+        writable: true
+    });    
+
+    Object.defineProperty(handler, 'mobileAnalyticsHelper', {
+        value: null,
+        writable: true
+    });   
+
     handler.registerHandlers(responseHandlers);
 
     return handler;
@@ -100,6 +111,8 @@ function alexaRequestHandler(event, context, callback) {
 
 function HandleLambdaEvent() {
     this.locale = this._event.request.locale;
+    this.mobileAnalyticsSettings.locale = this.locale;
+
     if(this.resources) {
         this.i18n.use(sprintf).init({
             overloadTranslationOptionHandler: sprintf.overloadTranslationOptionHandler,
@@ -134,6 +147,13 @@ function ValidateRequest() {
         userId = event.session.user.userId;
     }
 
+    if (!this.mobileAnalyticsSettings.clientId) {
+        this.mobileAnalyticsSettings.clientId = userId;
+    }
+
+    if (this.mobileAnalyticsSettings && this.mobileAnalyticsSettings.appId) {
+        this.mobileAnalyticsHelper = new mobileAnalyticsHelper(this.mobileAnalyticsSettings);
+    }
 
     if(!handlerAppId){
         console.log('Warning: Application ID is not set');
@@ -145,6 +165,31 @@ function ValidateRequest() {
             console.log(`The applicationIds don\'t match: ${requestAppId} and ${handlerAppId}`);
             return context.fail('Invalid ApplicationId: ' + handlerAppId);
         }
+
+        if (this.mobileAnalyticsHelper) {
+
+            if (event.session.sessionId && event.session['new']) {
+                this.mobileAnalyticsHelper.startSession(event.session.sessionId);
+            }
+
+            var maAttributes = {};
+
+            if (event.request.intent) {
+                maAttributes['IntentName'] = event.request.intent.name;
+            
+                if (event.request.intent.slots != undefined) {
+                    for (var key in event.request.intent.slots) {
+                        if (event.request.intent.slots.hasOwnProperty(key)) {
+                            var name = event.request.intent.slots[key].name;
+                            maAttributes[name] = event.request.intent.slots[key].value;
+                        }
+                    }
+                }
+            }                
+
+            this.mobileAnalyticsHelper.recordEvent(event.request.type, event.session.sessionId, maAttributes);
+        }
+
 
         if(this.dynamoDBTableName && (!event.session.sessionId || event.session['new']) ) {
             attributesHelper.get(this.dynamoDBTableName, userId, (err, data) => {
@@ -222,6 +267,10 @@ function RegisterHandlers() {
                 return this.i18n.t.apply(this.i18n, arguments);
             };
 
+            var recordEvent = function() {
+                return this.mobileAnalyticsHelper.recordEvent.apply(this.mobileAnalyticsHelper, arguments);
+            }
+
             var handlerContext = {
                 on: this.on.bind(this),
                 emit: this.emit.bind(this),
@@ -236,7 +285,8 @@ function RegisterHandlers() {
                 context: this._context,
                 name: eventName,
                 isOverridden:  IsOverridden.bind(this, eventName),
-                response: ResponseBuilder(this)
+                response: ResponseBuilder(this),
+                recordMobileAnalyticsEvent: recordEvent
             };
 
             this.on(eventName, handlerObject[eventNames[i]].bind(handlerContext));

--- a/lib/alexa.js
+++ b/lib/alexa.js
@@ -111,7 +111,11 @@ function alexaRequestHandler(event, context, callback) {
 
 function HandleLambdaEvent() {
     this.locale = this._event.request.locale;
-    this.mobileAnalyticsSettings.locale = this.locale;
+
+    if (this.mobileAnalyticsSettings) {
+        this.mobileAnalyticsSettings.locale = this.locale;
+    }
+    
 
     if(this.resources) {
         this.i18n.use(sprintf).init({
@@ -147,7 +151,7 @@ function ValidateRequest() {
         userId = event.session.user.userId;
     }
 
-    if (!this.mobileAnalyticsSettings.clientId) {
+    if (this.mobileAnalyticsSettings && !this.mobileAnalyticsSettings.clientId) {
         this.mobileAnalyticsSettings.clientId = userId;
     }
 
@@ -166,7 +170,7 @@ function ValidateRequest() {
             return context.fail('Invalid ApplicationId: ' + handlerAppId);
         }
 
-        if (this.mobileAnalyticsHelper) {
+        if (this.mobileAnalyticsHelper && this.mobileAnalyticsSettings) {
 
             this.mobileAnalyticsHelper._recordRequest(event, (err, data) => {
 

--- a/lib/alexa.js
+++ b/lib/alexa.js
@@ -100,7 +100,7 @@ function alexaRequestHandler(event, context, callback) {
     });    
 
     Object.defineProperty(handler, 'mobileAnalyticsHelper', {
-        value: null,
+        value: new mobileAnalyticsHelper(),
         writable: true
     });   
 
@@ -152,7 +152,7 @@ function ValidateRequest() {
     }
 
     if (this.mobileAnalyticsSettings && this.mobileAnalyticsSettings.appId) {
-        this.mobileAnalyticsHelper = new mobileAnalyticsHelper(this.mobileAnalyticsSettings);
+        this.mobileAnalyticsHelper._init(this.mobileAnalyticsSettings);
     }
 
     if(!handlerAppId){
@@ -168,33 +168,13 @@ function ValidateRequest() {
 
         if (this.mobileAnalyticsHelper) {
 
-            var eventType = event.request.type;
-            var isNewSession =  event.session['new'];
+            this.mobileAnalyticsHelper._recordRequest(event, (err, data) => {
 
-            if (event.session.sessionId && isNewSession) {
-                this.mobileAnalyticsHelper.startSession(event.session.sessionId);
-            }
+                this._event.session.attributes.sessionStartTimestamp =  this.mobileAnalyticsHelper.startTimestamp;
+                
+            });
 
-            var maAttributes = {
-                NewSession: isNewSession.toString()
-            };            
-
-            if (event.request.intent) {
-                eventType = event.request.intent.name;
-            
-                if (event.request.intent.slots != undefined) {
-                    for (var key in event.request.intent.slots) {
-                        if (event.request.intent.slots.hasOwnProperty(key)) {
-                            var name = event.request.intent.slots[key].name;
-                            maAttributes[name] = event.request.intent.slots[key].value;
-                        }
-                    }
-                }
-            }                
-
-            this.mobileAnalyticsHelper.recordEvent(eventType, event.session.sessionId, maAttributes);
         }
-
 
         if(this.dynamoDBTableName && (!event.session.sessionId || event.session['new']) ) {
             attributesHelper.get(this.dynamoDBTableName, userId, (err, data) => {
@@ -291,6 +271,7 @@ function RegisterHandlers() {
                 name: eventName,
                 isOverridden:  IsOverridden.bind(this, eventName),
                 response: ResponseBuilder(this),
+                mobileAnalyticsHelper: this.mobileAnalyticsHelper,
                 recordMobileAnalyticsEvent: recordEvent
             };
 
@@ -451,15 +432,6 @@ function EmitWithState() {
         throw new Error('EmitWithState called without arguments');
     }
     arguments[0] = arguments[0] + this.state;
-
-    if (this.listenerCount(arguments[0]) < 1) {
-        arguments[0] = 'Unhandled' + this.state;
-    }
-
-    if (this.listenerCount(arguments[0]) < 1) {
-        throw new Error(`No 'Unhandled' function defined for event: ${arguments[0]}`);
-    }
-
     this.emit.apply(this, arguments);
 }
 

--- a/lib/alexa.js
+++ b/lib/alexa.js
@@ -168,6 +168,8 @@ function ValidateRequest() {
 
         if (this.mobileAnalyticsHelper) {
 
+            var eventType = event.request.type;
+
             if (event.session.sessionId && event.session['new']) {
                 this.mobileAnalyticsHelper.startSession(event.session.sessionId);
             }
@@ -175,7 +177,7 @@ function ValidateRequest() {
             var maAttributes = {};
 
             if (event.request.intent) {
-                maAttributes['IntentName'] = event.request.intent.name;
+                eventType = event.request.intent.name;
             
                 if (event.request.intent.slots != undefined) {
                     for (var key in event.request.intent.slots) {
@@ -187,7 +189,7 @@ function ValidateRequest() {
                 }
             }                
 
-            this.mobileAnalyticsHelper.recordEvent(event.request.type, event.session.sessionId, maAttributes);
+            this.mobileAnalyticsHelper.recordEvent(eventType, event.session.sessionId, maAttributes);
         }
 
 

--- a/lib/alexa.js
+++ b/lib/alexa.js
@@ -169,12 +169,15 @@ function ValidateRequest() {
         if (this.mobileAnalyticsHelper) {
 
             var eventType = event.request.type;
+            var isNewSession =  event.session['new'];
 
-            if (event.session.sessionId && event.session['new']) {
+            if (event.session.sessionId && isNewSession) {
                 this.mobileAnalyticsHelper.startSession(event.session.sessionId);
             }
 
-            var maAttributes = {};
+            var maAttributes = {
+                NewSession: isNewSession.toString()
+            };            
 
             if (event.request.intent) {
                 eventType = event.request.intent.name;

--- a/lib/response.js
+++ b/lib/response.js
@@ -94,15 +94,23 @@ module.exports = (function () {
                 this.handler.response.sessionAttributes['STATE'] = this.handler.state;
             }
 
-            if (this.handler.dynamoDBTableName) {
-                return this.emit(':saveState');
-            }
+            if (this.handler.response.response.shouldEndSession) {
+                this.handler.mobileAnalyticsHelper._stopSession(this.handler._event.session.sessionId, (err, data) => {
+                
+                    if (this.handler.dynamoDBTableName) {
+                        return this.emit(':saveState');
+                    }
+                    this.context.succeed(this.handler.response);
 
-            if (this.handler.response.shouldEndSession) {
-                this.handler.mobileAnalyticsHelper.stopSession(this.handler._event.session.sessionId);
+                });
             }
+            else {
 
-            this.context.succeed(this.handler.response);
+                if (this.handler.dynamoDBTableName) {
+                    return this.emit(':saveState');
+                }
+                this.context.succeed(this.handler.response);
+            }
         },
         ':saveState': function(forceSave) {
             if (this.isOverridden()) {
@@ -122,8 +130,18 @@ module.exports = (function () {
                 userId = this.event.session.user.userId;
             }
 
+            
+
             if(this.saveBeforeResponse || forceSave || this.handler.response.response.shouldEndSession) {
-                attributesHelper.set(this.handler.dynamoDBTableName, userId, this.attributes,
+
+                // Remove sessionStartTimestamp so it does not get persisted to dynamoDB.
+                // We still want it on the response, so it is available on the next request.
+                var copyAttributes = Object.assign({}, this.attributes);    
+                if (copyAttributes.sessionStartTimestamp) {
+                    delete copyAttributes.sessionStartTimestamp;
+                }
+                
+                attributesHelper.set(this.handler.dynamoDBTableName, userId, copyAttributes,
                     (err) => {
                         if(err) {
                             return this.emit(':saveStateError', err);

--- a/lib/response.js
+++ b/lib/response.js
@@ -98,6 +98,10 @@ module.exports = (function () {
                 return this.emit(':saveState');
             }
 
+            if (this.handler.response.shouldEndSession) {
+                this.handler.mobileAnalyticsHelper.stopSession(this.handler._event.session.sessionId);
+            }
+
             this.context.succeed(this.handler.response);
         },
         ':saveState': function(forceSave) {


### PR DESCRIPTION
With a single setting, all LaunchRequest, IntentRequest, and SessionEndedRequest request types are automatically tracked in Mobile Analytics including adding a new session flag and all slots as attributes to the tracking event. Tracks start and stop of sessions across requests. Even allows for tracking custom events in intent handler functions.
