### PR TITLE
Allow a ":tell" response to keep the session alive (option 1)

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -3,7 +3,7 @@ var attributesHelper = require('./DynamoAttributesHelper');
 
 module.exports = (function () {
     return {
-        ':tell': function (speechOutput) {
+        ':tell': function (speechOutput, keepSession) {
             if(this.isOverridden()) {
                 return;
             }
@@ -11,7 +11,7 @@ module.exports = (function () {
             this.handler.response = buildSpeechletResponse({
                 sessionAttributes: this.attributes,
                 output: getSSMLResponse(speechOutput),
-                shouldEndSession: true
+                shouldEndSession: !!keepSession
             });
             this.emit(':responseReady');
         },


### PR DESCRIPTION
Added an extra parameter to allow for a ":tell" response to keep the session alive.

Only one of this or https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/pull/37 is required to achieve the desired functionality.