### PR TITLE
Allow a ":tell" response to keep the session alive (option 2)

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -15,6 +15,18 @@ module.exports = (function () {
             });
             this.emit(':responseReady');
         },
+				':tellWithSession': function (speechOutput) {
+					if(this.isOverridden()) {
+						return;
+					}
+
+					this.handler.response = buildSpeechletResponse({
+						sessionAttributes: this.attributes,
+						output: getSSMLResponse(speechOutput),
+						shouldEndSession: false
+					});
+					this.emit(':responseReady');
+				},
         ':ask': function (speechOutput, repromptSpeech) {
             if(this.isOverridden()) {
                 return;


### PR DESCRIPTION
Added a new response type - '':tellWithSession'. Identical to the old ':tell' type, but keeping the session alive

Only one of this or https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/pull/36 is required to achieve the desired functionality.