### PR TITLE
Removes Exception Handler

### DIFF
--- a/lib/alexa.js
+++ b/lib/alexa.js
@@ -408,11 +408,6 @@ function EmitWithState() {
     this.emit.apply(this, arguments);
 }
 
-process.on('uncaughtException', function(err) {
-    console.log(`Uncaught exception: ${err}\n${err.stack}`);
-    throw err;
-});
-
 module.exports.LambdaHandler = alexaRequestHandler;
 module.exports.CreateStateHandler = createStateHandler;
 module.exports.StateString = _StateString;


### PR DESCRIPTION
Catching the exception and throwing it again is redundant and can override other exception handling.