### PR TITLE
Adding option for not saving user's state to the DB

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -85,7 +85,7 @@ module.exports = (function () {
             });
             this.emit(':responseReady');
         },
-        ':responseReady': function () {
+        ':responseReady': function (cleanState) {
             if (this.isOverridden()) {
                 return;
             }
@@ -95,20 +95,18 @@ module.exports = (function () {
             }
 
             if (this.handler.dynamoDBTableName) {
-                return this.emit(':saveState');
+                return this.emit(':saveState', cleanState);
             }
 
             this.context.succeed(this.handler.response);
         },
-        ':saveState': function(forceSave) {
+        ':saveState': function(forceSave, cleanState) {
             if (this.isOverridden()) {
                 return;
             }
 
             if(forceSave && this.handler.state){
                 this.attributes['STATE'] = this.handler.state;
-            } else if(!forceSave) {
-                delete this.attributes['STATE'];
             }
 
             var userId = '';
@@ -118,6 +116,10 @@ module.exports = (function () {
                 userId = this.event.context.System.user.userId;
             } else if (this.event.session) {
                 userId = this.event.session.user.userId;
+            }
+
+            if(cleanState) {
+                delete this.attributes['STATE'];
             }
 
             if(this.saveBeforeResponse || forceSave || this.handler.response.response.shouldEndSession) {

--- a/lib/response.js
+++ b/lib/response.js
@@ -107,6 +107,8 @@ module.exports = (function () {
 
             if(forceSave && this.handler.state){
                 this.attributes['STATE'] = this.handler.state;
+            } else if(!forceSave) {
+                delete this.attributes['STATE'];
             }
 
             var userId = '';

--- a/lib/response.js
+++ b/lib/response.js
@@ -95,7 +95,7 @@ module.exports = (function () {
             }
 
             if (this.handler.dynamoDBTableName) {
-                return this.emit(':saveState', cleanState);
+                return this.emit(':saveState', false, cleanState);
             }
 
             this.context.succeed(this.handler.response);


### PR DESCRIPTION
You might not want to save the user's current STATE. This should be optional, in case you want to store other attributes only, for example, the user's time zone.

I don't know why STATE is ALWAYS saved in Dynamo. This should be OPTIONAL.