### PR TITLE
Allow state to be reset to empty string

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -90,7 +90,7 @@ module.exports = (function () {
                 return;
             }
 
-            if(this.handler.state) {
+            if(this.handler.state || this.handler.state === '') {
                 this.handler.response.sessionAttributes['STATE'] = this.handler.state;
             }
 


### PR DESCRIPTION
The current `if(this.handler.state)` doesn't allow the state to be reset to an empty string (''), as an empty string is falsey, so evaluates to false. 

The problem with this is that an empty string is the default state that Alexa uses on opening a new session, so it's extremely useful to be able to return to this state. It's especially useful for the built-in AMAZON.StartOverIntent. 

I've been using this small fix for several days with no problems, and it very simply allows the state to be reset to an empty string.