### PR TITLE
Fix saveBeforeResponse

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -118,7 +118,7 @@ module.exports = (function () {
                 userId = this.event.session.user.userId;
             }
 
-            if(this.saveBeforeResponse || forceSave || this.handler.response.response.shouldEndSession) {
+            if(this.handler.saveBeforeResponse || forceSave || this.handler.response.response.shouldEndSession) {
                 attributesHelper.set(this.handler.dynamoDBTableName, userId, this.attributes,
                     (err) => {
                         if(err) {


### PR DESCRIPTION
Fixes a bug where setting `alexa.saveBeforeResponse = true` wouldn't make it save before the response. This is because when it checked for `saveBeforeResponse` in `this.emit(':saveState')`, it was checking for a property of `handlerContext` using `if(this.saveBeforeResponse [...])`. The problem is the `handlerContext` object doesn't have a defined `saveBeforeResponse` property. Therefore, it would just give 'undefined' which is falsey, and not save before the response as expected. 

With this change, it checks `this.handler.saveBeforeResponse`. This is the place where `saveBeforeResponse` is actually defined, as the handler does have a `saveBeforeResponse` property that defaults to false.