### PR TITLE
ES6 upgrade, full JSDocs, and make compatible with Google style guide

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var AlexaLambdaHandler = require('./lib/alexa');
+const AlexaLambdaHandler = require('./lib/alexa');
 
 module.exports.handler = AlexaLambdaHandler.LambdaHandler;
 module.exports.CreateStateHandler = AlexaLambdaHandler.CreateStateHandler;

--- a/lib/DynamoAttributesHelper.js
+++ b/lib/DynamoAttributesHelper.js
@@ -1,99 +1,98 @@
 'use strict';
-var aws = require('aws-sdk');
-var doc;
 
-module.exports = (function() {
-    return {
-        get: function(table, userId, callback) {
-            if(!table) {
-                callback('DynamoDB Table name is not set.', null);
-            }
+const aws = require('aws-sdk');
 
-            if(!doc) {
-                doc = new aws.DynamoDB.DocumentClient({apiVersion: '2012-08-10'});
-            }
-
-            var params = {
-                Key: {
-                    userId: userId
-                },
-                TableName: table,
-                ConsistentRead: true
-            };
-
-            doc.get(params, function(err, data){
-                if(err) {
-                    console.log('get error: ' + JSON.stringify(err, null, 4));
-
-                    if(err.code === 'ResourceNotFoundException') {
-                        var dynamoClient = new aws.DynamoDB();
-                        newTableParams['TableName'] = table;
-                        dynamoClient.createTable(newTableParams, function (err, data) {
-                            if(err) {
-                                console.log('Error creating table: ' + JSON.stringify(err, null, 4));
-                            }
-                            console.log('Creating table ' + table + ':\n' + JSON.stringify(data));
-                            callback(err, {});
-                        });
-                    } else {
-                        callback(err, null);
-                    }
-                } else {
-                    if(isEmptyObject(data)) {
-                        callback(null, {});
-                    } else {
-                        callback(null, data.Item['mapAttr']);
-                    }
-                }
-            });
-        },
-
-        set: function(table, userId, data, callback) {
-            if(!table) {
-                callback('DynamoDB Table name is not set.', null);
-            }
-
-            if(!doc) {
-                doc = new aws.DynamoDB.DocumentClient({apiVersion: '2012-08-10'});
-            }
-
-            var params = {
-                Item: {
-                    userId: userId,
-                    mapAttr: data
-                },
-                TableName: table
-            };
-
-            doc.put(params, function(err, data) {
-                if(err) {
-                    console.log('Error during DynamoDB put:' + err);
-                }
-                callback(err, data);
-            });
-        }
-    };
-})();
+const newTableParams = {
+  AttributeDefinitions: [
+    {
+      AttributeName: 'userId',
+      AttributeType: 'S',
+    },
+  ],
+  KeySchema: [
+    {
+      AttributeName: 'userId',
+      KeyType: 'HASH',
+    },
+  ],
+  ProvisionedThroughput: {
+    ReadCapacityUnits: 5,
+    WriteCapacityUnits: 5,
+  },
+};
 
 function isEmptyObject(obj) {
-    return !Object.keys(obj).length;
+  return !Object.keys(obj).length;
 }
 
-var newTableParams = {
-    AttributeDefinitions: [
-        {
-            AttributeName: 'userId',
-            AttributeType: 'S'
+module.exports = (function exported() {
+  let doc;
+  return {
+    get(table, userId, callback) {
+      if (!table) {
+        callback('DynamoDB Table name is not set.', null);
+      }
+
+      if (!doc) {
+        doc = new aws.DynamoDB.DocumentClient({ apiVersion: '2012-08-10' });
+      }
+
+      const params = {
+        Key: {
+          userId,
+        },
+        TableName: table,
+        ConsistentRead: true,
+      };
+
+      doc.get(params, (err, data) => {
+        if (err) {
+          console.log(`get error: ${JSON.stringify(err, null, 4)}`);
+
+          if (err.code === 'ResourceNotFoundException') {
+            const dynamoClient = new aws.DynamoDB();
+            newTableParams.TableName = table;
+            dynamoClient.createTable(newTableParams, (createErr, createData) => {
+              if (createErr) {
+                console.log(`Error creating table: ${JSON.stringify(createErr, null, 4)}`);
+              }
+              console.log(`'Creating table ${table}:\n ${JSON.stringify(createData)}`);
+              callback(createErr, {});
+            });
+          } else {
+            callback(err, null);
+          }
+        } else if (isEmptyObject(data)) {
+          callback(null, {});
+        } else {
+          callback(null, data.Item.mapAttr);
         }
-    ],
-    KeySchema: [
-        {
-            AttributeName: 'userId',
-            KeyType: 'HASH'
+      });
+    },
+
+    set(table, userId, data, callback) {
+      if (!table) {
+        callback('DynamoDB Table name is not set.', null);
+      }
+
+      if (!doc) {
+        doc = new aws.DynamoDB.DocumentClient({ apiVersion: '2012-08-10' });
+      }
+
+      const params = {
+        Item: {
+          userId,
+          mapAttr: data,
+        },
+        TableName: table,
+      };
+
+      doc.put(params, (putErr, putData) => {
+        if (putErr) {
+          console.log(`Error during DynamoDB put: ${putErr}`);
         }
-    ],
-    ProvisionedThroughput: {
-        ReadCapacityUnits: 5,
-        WriteCapacityUnits: 5
-    }
-};
+        callback(putErr, putData);
+      });
+    },
+  };
+}());

--- a/lib/DynamoAttributesHelper.js
+++ b/lib/DynamoAttributesHelper.js
@@ -2,35 +2,6 @@
 
 const aws = require('aws-sdk');
 
-const newTableParams = {
-  AttributeDefinitions: [
-    {
-      AttributeName: 'userId',
-      AttributeType: 'S',
-    },
-  ],
-  KeySchema: [
-    {
-      AttributeName: 'userId',
-      KeyType: 'HASH',
-    },
-  ],
-  ProvisionedThroughput: {
-    ReadCapacityUnits: 5,
-    WriteCapacityUnits: 5,
-  },
-};
-
-/**
- * isEmptyObject - Detect if object is empty.
- *
- * @param  {Object} obj   Object to check
- * @return {boolean}      If object is empty.
- */
-function isEmptyObject(obj) {
-  return !Object.keys(obj).length;
-}
-
 /**
  * Callback used by get/put.
  *
@@ -39,10 +10,9 @@ function isEmptyObject(obj) {
  * @param {string} data   Object containing saved attributes
  */
 
-module.exports = (function exported() {
+module.exports = (function() {
   let doc;
   return {
-
     /**
      * get - Retrieve saved user attributes from DynamoDB table.
      *
@@ -57,7 +27,7 @@ module.exports = (function exported() {
       }
 
       if (!doc) {
-        doc = new aws.DynamoDB.DocumentClient({ apiVersion: '2012-08-10' });
+        doc = new aws.DynamoDB.DocumentClient({apiVersion: '2012-08-10'});
       }
 
       const params = {
@@ -108,7 +78,7 @@ module.exports = (function exported() {
       }
 
       if (!doc) {
-        doc = new aws.DynamoDB.DocumentClient({ apiVersion: '2012-08-10' });
+        doc = new aws.DynamoDB.DocumentClient({apiVersion: '2012-08-10'});
       }
 
       const params = {
@@ -128,3 +98,32 @@ module.exports = (function exported() {
     },
   };
 }());
+
+/**
+ * isEmptyObject - Detect if object is empty.
+ *
+ * @param  {Object} obj   Object to check
+ * @return {boolean}      If object is empty.
+ */
+function isEmptyObject(obj) {
+  return !Object.keys(obj).length;
+}
+
+const newTableParams = {
+  AttributeDefinitions: [
+    {
+      AttributeName: 'userId',
+      AttributeType: 'S',
+    },
+  ],
+  KeySchema: [
+    {
+      AttributeName: 'userId',
+      KeyType: 'HASH',
+    },
+  ],
+  ProvisionedThroughput: {
+    ReadCapacityUnits: 5,
+    WriteCapacityUnits: 5,
+  },
+};

--- a/lib/DynamoAttributesHelper.js
+++ b/lib/DynamoAttributesHelper.js
@@ -21,13 +21,36 @@ const newTableParams = {
   },
 };
 
+/**
+ * isEmptyObject - Detect if object is empty.
+ *
+ * @param  {Object} obj   Object to check
+ * @return {boolean}      If object is empty.
+ */
 function isEmptyObject(obj) {
   return !Object.keys(obj).length;
 }
 
+/**
+ * Callback used by get/put.
+ *
+ * @callback dbCallback
+ * @param {number} err    Error getting or putting saved attributes
+ * @param {string} data   Object containing saved attributes
+ */
+
 module.exports = (function exported() {
   let doc;
   return {
+
+    /**
+     * get - Retrieve saved user attributes from DynamoDB table.
+     *
+     * @param  {string} table           Name of table
+     * @param  {string} userId          User ID to retrieve attributes of
+     * @param  {dbCallback} callback    Callback to handle data or error.
+     * @return {undefined}
+     */
     get(table, userId, callback) {
       if (!table) {
         callback('DynamoDB Table name is not set.', null);
@@ -70,6 +93,15 @@ module.exports = (function exported() {
       });
     },
 
+    /**
+     * set - Store user attributes in DynamoDB table.
+     *
+     * @param  {string} table         Name of table to store attributes
+     * @param  {string} userId        User ID
+     * @param  {object} data          Object containing attributes to store
+     * @param  {dbCallback} callback  Callback to handle data or error
+     * @return {undefined}
+     */
     set(table, userId, data, callback) {
       if (!table) {
         callback('DynamoDB Table name is not set.', null);

--- a/lib/alexa.js
+++ b/lib/alexa.js
@@ -9,13 +9,7 @@ const responseHandlers = require('./response');
 
 const _StateString = 'STATE';
 
-function AlexaRequestEmitter() {
-  EventEmitter.call(this);
-}
-
-util.inherits(AlexaRequestEmitter, EventEmitter);
-
-// class AlexaRequestEmitter extends EventEmitter {}
+class AlexaRequestEmitter extends EventEmitter {}
 
 function isObject(obj) {
   return (!!obj) && (obj.constructor === Object);

--- a/lib/alexa.js
+++ b/lib/alexa.js
@@ -91,14 +91,14 @@ function alexaRequestHandler(event, context, callback) {
   });
 
   Object.defineProperty(handler, 'registerHandlers', {
-    value: function registerHandlers(...args) {
+    value: (...args) => {
       RegisterHandlers.apply(handler, args);
     },
     writable: false,
   });
 
   Object.defineProperty(handler, 'execute', {
-    value: function execute() {
+    value: () => {
       HandleLambdaEvent.call(handler);
     },
     writable: false,

--- a/lib/alexa.js
+++ b/lib/alexa.js
@@ -9,8 +9,283 @@ const responseHandlers = require('./response');
 
 const _StateString = 'STATE';
 
-
+/**
+ * Class representing overall handler, to register intent listeners.
+ */
 class AlexaRequestEmitter extends EventEmitter {}
+
+/**
+ * alexaRequestHandler - Make handler object, and register built-in events from response.js
+ * Handler object extends EventEmitter.
+ *
+ * @param  {Object} event    Lambda event (request body)
+ * @param  {Object} context  Lambda context
+ * @param  {Object} callback Lambda callback
+ * @return {Object}          AlexaRequestEmitter with preregistered events registered.
+ */
+function alexaRequestHandler(event, context, callback) {
+  const newEvent = event;
+  if (!newEvent.session) {
+    newEvent.session = {attributes: {}};
+  } else if (!event.session.attributes) {
+    newEvent.session.attributes = {};
+  }
+
+  const handler = new AlexaRequestEmitter();
+  handler.setMaxListeners(Infinity);
+
+  Object.defineProperty(handler, '_event', {
+    value: newEvent,
+    writable: false,
+  });
+
+  Object.defineProperty(handler, '_context', {
+    value: context,
+    writable: false,
+  });
+
+  Object.defineProperty(handler, '_callback', {
+    value: callback,
+    writable: false,
+  });
+
+  Object.defineProperty(handler, 'state', {
+    value: null,
+    writable: true,
+    configurable: true,
+  });
+
+  Object.defineProperty(handler, 'appId', {
+    value: null,
+    writable: true,
+  });
+
+  Object.defineProperty(handler, 'response', {
+    value: {},
+    writable: true,
+  });
+
+  Object.defineProperty(handler, 'dynamoDBTableName', {
+    value: null,
+    writable: true,
+  });
+
+  Object.defineProperty(handler, 'saveBeforeResponse', {
+    value: false,
+    writable: true,
+  });
+
+  Object.defineProperty(handler, 'i18n', {
+    value: i18n,
+    writable: true,
+  });
+
+  Object.defineProperty(handler, 'locale', {
+    value: undefined,
+    writable: true,
+  });
+
+  Object.defineProperty(handler, 'resources', {
+    value: undefined,
+    writable: true,
+  });
+
+  Object.defineProperty(handler, 'registerHandlers', {
+    value: function registerHandlers(...args) {
+      RegisterHandlers.apply(handler, args);
+    },
+    writable: false,
+  });
+
+  Object.defineProperty(handler, 'execute', {
+    value: function execute() {
+      HandleLambdaEvent.call(handler);
+    },
+    writable: false,
+  });
+
+  Object.defineProperty(handler, 't', {
+    value: function t(...args) {
+      return this.i18n.t(...args);
+    },
+  });
+
+  handler.registerHandlers(responseHandlers);
+
+  return handler;
+}
+
+/**
+ * HandleLambdaEvent - Set up i18next translation backend, then call ValidateRequest.
+ *
+ * NB: this keyword must be bound to handler object.
+ *
+ * @return {undefined}
+ */
+function HandleLambdaEvent() {
+  this.locale = this._event.request.locale;
+  if (this.resources) {
+    this.i18n.use(sprintf).init({
+      overloadTranslationOptionHandler: sprintf.overloadTranslationOptionHandler,
+      returnObjects: true,
+      lng: this.locale,
+      resources: this.resources,
+    }, (err) => {
+      if (err) {
+        throw new Error(`Error initializing i18next: ${err}`);
+      }
+      ValidateRequest.call(this);
+    });
+  } else {
+    ValidateRequest.call(this);
+  }
+}
+
+/**
+ * ValidateRequest - Check that App IDs match, get attributes from DynamoDB, then call EmitEvent.
+ *
+ * NB: this keyword must be bound to handler object.
+ *
+ * @return {undefined}
+ */
+function ValidateRequest() {
+  const event = this._event;
+  const context = this._context;
+  const handlerAppId = this.appId;
+
+  let requestAppId = '';
+  let userId = '';
+
+  // Long-form audio enabled skills use event.context
+  if (event.context) {
+    requestAppId = event.context.System.application.applicationId;
+    userId = event.context.System.user.userId;
+  } else if (event.session) {
+    requestAppId = event.session.application.applicationId;
+    userId = event.session.user.userId;
+  }
+
+  if (!handlerAppId) {
+    console.log('Warning: Application ID is not set');
+  }
+
+  try {
+    // Validate that this request originated from authorized source.
+    if (handlerAppId && (requestAppId !== handlerAppId)) {
+      console.log(`The applicationIds don't match: ${requestAppId} and ${handlerAppId}`);
+      context.fail(`Invalid ApplicationId: ${handlerAppId}`);
+      return;
+    }
+
+    if (this.dynamoDBTableName && (!event.session.sessionId || event.session.new)) {
+      attributesHelper.get(this.dynamoDBTableName, userId, (err, data) => {
+        if (err) {
+          context.fail(`Error fetching user state: ${err}`);
+          return;
+        }
+        Object.assign(this._event.session.attributes, data);
+      });
+    }
+    EmitEvent.call(this);
+  } catch (e) {
+    console.log(`Unexpected exception '${e}':\n${e.stack}`);
+    context.fail(e);
+  }
+}
+
+/**
+ * EmitEvent - Parse lambda event and emit correct event string to handler.
+ *
+ * NB: this keyword must be bound to handler object.
+ *
+ * @fires eventString based off event.request
+ * @return {undefined}
+ */
+function EmitEvent() {
+  this.state = this._event.session.attributes[_StateString] || '';
+
+  let eventString = '';
+
+  if (this._event.session.new && this.listenerCount(`NewSession${this.state}`) === 1) {
+    eventString = 'NewSession';
+  } else if (this._event.request.type === 'LaunchRequest') {
+    eventString = 'LaunchRequest';
+  } else if (this._event.request.type === 'IntentRequest') {
+    eventString = this._event.request.intent.name;
+  } else if (this._event.request.type === 'SessionEndedRequest') {
+    eventString = 'SessionEndedRequest';
+  } else if (this._event.request.type.substring(0, 11) === 'AudioPlayer') {
+    eventString = this._event.request.type.substring(12);
+  } else if (this._event.request.type.substring(0, 18) === 'PlaybackController') {
+    eventString = this._event.request.type.substring(19);
+  }
+
+  eventString += this.state;
+
+  if (this.listenerCount(eventString) < 1) {
+    eventString = `Unhandled${this.state}`;
+  }
+
+  if (this.listenerCount(eventString) < 1) {
+    throw new Error(`No 'Unhandled' function defined for event: ${eventString}`);
+  }
+
+  this.emit(eventString);
+}
+
+/**
+ * RegisterHandlers - Add all handlers to this, adding events for each property.
+ *
+ * NB: this keyword must be bound to handler object.
+ *
+ * @param  {...Object} args  Array of all handlers to register
+ * @return {undefined}
+ */
+function RegisterHandlers(...args) {
+  for (let arg = 0; arg < args.length; arg += 1) {
+    const handlerObject = args[arg];
+
+    if (!isObject(handlerObject)) {
+      throw new Error(`Argument #${arg} was not an Object`);
+    }
+
+    const eventNames = Object.keys(handlerObject);
+
+    for (let i = 0; i < eventNames.length; i += 1) {
+      if (typeof (handlerObject[eventNames[i]]) !== 'function') {
+        throw new Error(`Event handler for '${eventNames[i]}' was not a function`);
+      }
+
+      let eventName = eventNames[i];
+
+      if (handlerObject[_StateString]) {
+        eventName += handlerObject[_StateString];
+      }
+
+      /**
+       * Context that registered handlers are bound too.
+       */
+      const handlerContext = {
+        on: this.on.bind(this),
+        emit: this.emit.bind(this),
+        emitWithState: EmitWithState.bind(this),
+        state: this.state,
+        handler: this,
+        i18n: this.i18n,
+        locale: this.locale,
+        t: this.t,
+        event: this._event,
+        attributes: this._event.session.attributes,
+        context: this._context,
+        name: eventName,
+        isOverridden: IsOverridden.bind(this, eventName),
+        response: responseBuilder(this),
+      };
+
+      this.on(eventName, handlerObject[eventNames[i]].bind(handlerContext));
+    }
+  }
+}
 
 /**
  * isObject - Detect whether parameter is an object
@@ -29,27 +304,10 @@ function isObject(obj) {
  *      This simply checks if there's more than one listener.
  *
  * @param  {string} name     Event name to be checked
- * @return {boolean}         If there is more than one listener for the event name
+ * @return {boolean}         If there is more than one listener for the event.
  */
 function IsOverridden(name) {
   return this.listenerCount(name) > 1;
-}
-
-
-/**
- * createSSMLSpeechObject - Form SSML Object from string.
- *                          String is wrapped in <speak> tags.
- *
- * NB: Cannot detect SSML-specific characters, so they must be escaped with backslash.
- *
- * @param  {string} message String to wrap
- * @return {Object}         SSML object containing wrapped string
- */
-function createSSMLSpeechObject(message) {
-  return {
-    type: 'SSML',
-    ssml: `<speak> ${message} </speak>`,
-  };
 }
 
 /**
@@ -58,7 +316,7 @@ function createSSMLSpeechObject(message) {
  * @param  {Object} self  Object to take response from, and set response too
  * @return {Object}       Object with methods to create your own response
  */
-function ResponseBuilder(self) {
+function responseBuilder(self) {
   const responseObject = self.response;
   responseObject.version = '1.0';
   responseObject.response = {
@@ -145,8 +403,8 @@ function ResponseBuilder(self) {
       /**
        * audioPlayer - Set up audio player directive, using any directive type.
        *
-       * @param  {string} directiveType         Type of directive: either 'play', 'stop', or 'clearqueue'
-       * @param  {string} behavior              Playback behaviour: either 'REPLACE_ALL', 'ENQUEUE', or 'REPLACE_ENQUEUED'
+       * @param  {string} directiveType         Type of directive: 'play', 'stop', or 'clearqueue'
+       * @param  {string} behavior              Playback behaviour: 'REPLACE_ALL', 'ENQUEUE', or 'REPLACE_ENQUEUED'
        * @param  {string} url                   URL of audio stream
        * @param  {string} token                 Opaque token representing audio stream
        * @param  {string} expectedPreviousToken Opaque token representing previous audio stream
@@ -186,7 +444,7 @@ function ResponseBuilder(self) {
       /**
        * audioPlayerPlay - Set up audio player directive, using 'AudioPlayer.Play' directive type.
        *
-       * @param  {string} behavior              Playback behaviour: either 'REPLACE_ALL', 'ENQUEUE', or 'REPLACE_ENQUEUED'
+       * @param  {string} behavior              Playback behaviour: 'REPLACE_ALL', 'ENQUEUE', or 'REPLACE_ENQUEUED'
        * @param  {string} url                   URL of audio stream
        * @param  {string} token                 Opaque token representing audio stream
        * @param  {string} expectedPreviousToken Opaque token representing previous audio stream
@@ -244,6 +502,21 @@ function ResponseBuilder(self) {
   }());
 }
 
+/**
+ * createSSMLSpeechObject - Form SSML Object from string.
+ *                          String is wrapped in <speak> tags.
+ *
+ * NB: Can't detect SSML-specific characters; they must be escaped with `\`.
+ *
+ * @param  {string} message String to wrap
+ * @return {Object}         SSML object containing wrapped string
+ */
+function createSSMLSpeechObject(message) {
+  return {
+    type: 'SSML',
+    ssml: `<speak> ${message} </speak>`,
+  };
+}
 
 /**
  * createStateHandler - Make a handler, and sets its _StateString property.
@@ -295,281 +568,6 @@ function EmitWithState(intent, ...args) {
   this.emit(stateIntent, args);
 }
 
-
-/**
- * EmitEvent - Parse lambda event and emit correct event string to handler.
- *
- * NB: this keyword must be bound to handler object.
- *
- * @fires eventString
- * @return {undefined}
- */
-function EmitEvent() {
-  this.state = this._event.session.attributes[_StateString] || '';
-
-  let eventString = '';
-
-  if (this._event.session.new && this.listenerCount(`NewSession${this.state}`) === 1) {
-    eventString = 'NewSession';
-  } else if (this._event.request.type === 'LaunchRequest') {
-    eventString = 'LaunchRequest';
-  } else if (this._event.request.type === 'IntentRequest') {
-    eventString = this._event.request.intent.name;
-  } else if (this._event.request.type === 'SessionEndedRequest') {
-    eventString = 'SessionEndedRequest';
-  } else if (this._event.request.type.substring(0, 11) === 'AudioPlayer') {
-    eventString = this._event.request.type.substring(12);
-  } else if (this._event.request.type.substring(0, 18) === 'PlaybackController') {
-    eventString = this._event.request.type.substring(19);
-  }
-
-  eventString += this.state;
-
-  if (this.listenerCount(eventString) < 1) {
-    eventString = `Unhandled${this.state}`;
-  }
-
-  if (this.listenerCount(eventString) < 1) {
-    throw new Error(`No 'Unhandled' function defined for event: ${eventString}`);
-  }
-
-  this.emit(eventString);
-}
-
-
-/**
- * ValidateRequest - Check that App IDs match, get attributes from DynamoDB, then call EmitEvent.
- *
- * NB: this keyword must be bound to handler object.
- *
- * @return {undefined}
- */
-function ValidateRequest() {
-  const event = this._event;
-  const context = this._context;
-  const handlerAppId = this.appId;
-
-  let requestAppId = '';
-  let userId = '';
-
-  // Long-form audio enabled skills use event.context
-  if (event.context) {
-    requestAppId = event.context.System.application.applicationId;
-    userId = event.context.System.user.userId;
-  } else if (event.session) {
-    requestAppId = event.session.application.applicationId;
-    userId = event.session.user.userId;
-  }
-
-  if (!handlerAppId) {
-    console.log('Warning: Application ID is not set');
-  }
-
-  try {
-    // Validate that this request originated from authorized source.
-    if (handlerAppId && (requestAppId !== handlerAppId)) {
-      console.log(`The applicationIds don't match: ${requestAppId} and ${handlerAppId}`);
-      context.fail(`Invalid ApplicationId: ${handlerAppId}`);
-      return;
-    }
-
-    if (this.dynamoDBTableName && (!event.session.sessionId || event.session.new)) {
-      attributesHelper.get(this.dynamoDBTableName, userId, (err, data) => {
-        if (err) {
-          context.fail(`Error fetching user state: ${err}`);
-          return;
-        }
-        Object.assign(this._event.session.attributes, data);
-      });
-    }
-    EmitEvent.call(this);
-  } catch (e) {
-    console.log(`Unexpected exception '${e}':\n${e.stack}`);
-    context.fail(e);
-  }
-}
-
-
-/**
- * HandleLambdaEvent - Set up i18next translation backend, then call ValidateRequest.
- *
- * NB: this keyword must be bound to handler object.
- *
- * @return {undefined}
- */
-function HandleLambdaEvent() {
-  this.locale = this._event.request.locale;
-  if (this.resources) {
-    this.i18n.use(sprintf).init({
-      overloadTranslationOptionHandler: sprintf.overloadTranslationOptionHandler,
-      returnObjects: true,
-      lng: this.locale,
-      resources: this.resources,
-    }, (err) => {
-      if (err) {
-        throw new Error(`Error initializing i18next: ${err}`);
-      }
-      ValidateRequest.call(this);
-    });
-  } else {
-    ValidateRequest.call(this);
-  }
-}
-
-
-/**
- * RegisterHandlers - Add all handlers to this, adding events for each property.
- *
- * NB: this keyword must be bound to handler object.
- *
- * @param  {...Object} args  Array of all handlers to register
- * @return {undefined}
- */
-function RegisterHandlers(...args) {
-  for (let arg = 0; arg < args.length; arg += 1) {
-    const handlerObject = args[arg];
-
-    if (!isObject(handlerObject)) {
-      throw new Error(`Argument #${arg} was not an Object`);
-    }
-
-    const eventNames = Object.keys(handlerObject);
-
-    for (let i = 0; i < eventNames.length; i += 1) {
-      if (typeof (handlerObject[eventNames[i]]) !== 'function') {
-        throw new Error(`Event handler for '${eventNames[i]}' was not a function`);
-      }
-
-      let eventName = eventNames[i];
-
-      if (handlerObject[_StateString]) {
-        eventName += handlerObject[_StateString];
-      }
-
-      const localize = function localize(...localizeArgs) {
-        return this.i18n.t(...localizeArgs);
-      };
-
-      /**
-       * Context that registered handlers are bound too.
-       */
-      const handlerContext = {
-        on: this.on.bind(this),
-        emit: this.emit.bind(this),
-        emitWithState: EmitWithState.bind(this),
-        state: this.state,
-        handler: this,
-        i18n: this.i18n,
-        locale: this.locale,
-        t: localize,
-        event: this._event,
-        attributes: this._event.session.attributes,
-        context: this._context,
-        name: eventName,
-        isOverridden: IsOverridden.bind(this, eventName),
-        response: ResponseBuilder(this),
-      };
-
-      this.on(eventName, handlerObject[eventNames[i]].bind(handlerContext));
-    }
-  }
-}
-
-
-/**
- * alexaRequestHandler - Make handler object, and register built-in events from response.js
- * Handler object extends EventEmitter.
- *
- * @param  {Object} event    Lambda event (request body)
- * @param  {Object} context  Lambda context
- * @param  {Object} callback Lambda callback
- * @return {Object}          AlexaRequestEmitter with preregistered events registered.
- */
-function alexaRequestHandler(event, context, callback) {
-  const newEvent = event;
-  if (!newEvent.session) {
-    newEvent.session = { attributes: {} };
-  } else if (!event.session.attributes) {
-    newEvent.session.attributes = {};
-  }
-
-  const handler = new AlexaRequestEmitter();
-  handler.setMaxListeners(Infinity);
-
-  Object.defineProperty(handler, '_event', {
-    value: newEvent,
-    writable: false,
-  });
-
-  Object.defineProperty(handler, '_context', {
-    value: context,
-    writable: false,
-  });
-
-  Object.defineProperty(handler, '_callback', {
-    value: callback,
-    writable: false,
-  });
-
-  Object.defineProperty(handler, 'state', {
-    value: null,
-    writable: true,
-    configurable: true,
-  });
-
-  Object.defineProperty(handler, 'appId', {
-    value: null,
-    writable: true,
-  });
-
-  Object.defineProperty(handler, 'response', {
-    value: {},
-    writable: true,
-  });
-
-  Object.defineProperty(handler, 'dynamoDBTableName', {
-    value: null,
-    writable: true,
-  });
-
-  Object.defineProperty(handler, 'saveBeforeResponse', {
-    value: false,
-    writable: true,
-  });
-
-  Object.defineProperty(handler, 'i18n', {
-    value: i18n,
-    writable: true,
-  });
-
-  Object.defineProperty(handler, 'locale', {
-    value: undefined,
-    writable: true,
-  });
-
-  Object.defineProperty(handler, 'resources', {
-    value: undefined,
-    writable: true,
-  });
-
-  Object.defineProperty(handler, 'registerHandlers', {
-    value: function registerHandlers(...args) {
-      RegisterHandlers.apply(handler, args);
-    },
-    writable: false,
-  });
-
-  Object.defineProperty(handler, 'execute', {
-    value: function execute() {
-      HandleLambdaEvent.call(handler);
-    },
-    writable: false,
-  });
-
-  handler.registerHandlers(responseHandlers);
-
-  return handler;
-}
 
 module.exports.LambdaHandler = alexaRequestHandler;
 module.exports.CreateStateHandler = createStateHandler;

--- a/lib/alexa.js
+++ b/lib/alexa.js
@@ -1,418 +1,417 @@
 'use strict';
 
-var EventEmitter = require('events').EventEmitter;
-var util = require('util');
-var i18n = require('i18next');
-var sprintf = require('i18next-sprintf-postprocessor');
-var attributesHelper = require('./DynamoAttributesHelper');
-var responseHandlers = require('./response');
-var _StateString = 'STATE';
+const EventEmitter = require('events').EventEmitter;
+const util = require('util');
+const i18n = require('i18next');
+const sprintf = require('i18next-sprintf-postprocessor');
+const attributesHelper = require('./DynamoAttributesHelper');
+const responseHandlers = require('./response');
+
+const _StateString = 'STATE';
 
 function AlexaRequestEmitter() {
-    EventEmitter.call(this);
+  EventEmitter.call(this);
 }
 
 util.inherits(AlexaRequestEmitter, EventEmitter);
 
-function alexaRequestHandler(event, context, callback) {
-    if (!event.session) {
-        event.session = { 'attributes': {} };
-    } else if (!event.session['attributes']) {
-        event.session['attributes'] = {};
-    }
-
-    var handler = new AlexaRequestEmitter();
-    handler.setMaxListeners(Infinity);
-
-    Object.defineProperty(handler, '_event', {
-        value: event,
-        writable: false
-    });
-
-    Object.defineProperty(handler, '_context', {
-        value: context,
-        writable: false
-    });
-
-    Object.defineProperty(handler, '_callback', {
-        value: callback,
-        writable: false
-    });
-
-    Object.defineProperty(handler, 'state', {
-        value: null,
-        writable: true,
-        configurable: true
-    });
-
-    Object.defineProperty(handler, 'appId', {
-        value: null,
-        writable: true
-    });
-
-    Object.defineProperty(handler, 'response', {
-        value: {},
-        writable: true
-    });
-
-    Object.defineProperty(handler, 'dynamoDBTableName', {
-        value: null,
-        writable: true
-    });
-
-    Object.defineProperty(handler, 'saveBeforeResponse', {
-        value: false,
-        writable: true
-    });
-
-    Object.defineProperty(handler, 'i18n', {
-        value: i18n,
-        writable: true
-    });
-
-    Object.defineProperty(handler, 'locale', {
-        value: undefined,
-        writable: true
-    });
-
-    Object.defineProperty(handler, 'resources', {
-        value: undefined,
-        writable: true
-    });
-
-    Object.defineProperty(handler, 'registerHandlers', {
-        value: function() {
-            RegisterHandlers.apply(handler, arguments);
-        },
-        writable: false
-    });
-
-    Object.defineProperty(handler, 'execute', {
-        value: function() {
-            HandleLambdaEvent.call(handler);
-        },
-        writable: false
-    });
-
-    handler.registerHandlers(responseHandlers);
-
-    return handler;
-}
-
-function HandleLambdaEvent() {
-    this.locale = this._event.request.locale;
-    if(this.resources) {
-        this.i18n.use(sprintf).init({
-            overloadTranslationOptionHandler: sprintf.overloadTranslationOptionHandler,
-            returnObjects: true,
-            lng: this.locale,
-            resources: this.resources
-        }, (err, t) => {
-            if(err) {
-                throw new Error('Error initializing i18next: ' + err);
-            }
-            ValidateRequest.call(this);
-        });
-    } else {
-        ValidateRequest.call(this);
-    }
-}
-
-function ValidateRequest() {
-    var event = this._event;
-    var context = this._context;
-    var handlerAppId = this.appId;
-
-    var requestAppId = '';
-    var userId = '';
-
-    // Long-form audio enabled skills use event.context
-    if (event.context) {
-        requestAppId = event.context.System.application.applicationId;
-        userId = event.context.System.user.userId;
-    } else if (event.session) {
-        requestAppId = event.session.application.applicationId;
-        userId = event.session.user.userId;
-    }
-
-
-    if(!handlerAppId){
-        console.log('Warning: Application ID is not set');
-    }
-
-    try {
-        // Validate that this request originated from authorized source.
-        if (handlerAppId && (requestAppId !== handlerAppId)) {
-            console.log(`The applicationIds don\'t match: ${requestAppId} and ${handlerAppId}`);
-            return context.fail('Invalid ApplicationId: ' + handlerAppId);
-        }
-
-        if(this.dynamoDBTableName && (!event.session.sessionId || event.session['new']) ) {
-            attributesHelper.get(this.dynamoDBTableName, userId, (err, data) => {
-                if(err) {
-                    return context.fail('Error fetching user state: ' + err);
-                }
-
-                Object.assign(this._event.session.attributes, data);
-
-                EmitEvent.call(this);
-            });
-        } else {
-            EmitEvent.call(this);
-        }
-    } catch (e) {
-        console.log(`Unexpected exception '${e}':\n${e.stack}`);
-        context.fail(e);
-    }
-}
-
-function EmitEvent() {
-    this.state = this._event.session.attributes[_StateString] || '';
-
-    var eventString = '';
-
-    if (this._event.session['new'] && this.listenerCount('NewSession' + this.state) === 1) {
-        eventString = 'NewSession';
-    } else if(this._event.request.type === 'LaunchRequest') {
-        eventString = 'LaunchRequest';
-    } else if(this._event.request.type === 'IntentRequest') {
-        eventString = this._event.request.intent.name;
-    } else if (this._event.request.type === 'SessionEndedRequest'){
-        eventString = 'SessionEndedRequest';
-    } else if (this._event.request.type.substring(0,11) === 'AudioPlayer') {
-        eventString = this._event.request.type.substring(12);
-    } else if (this._event.request.type.substring(0,18) === 'PlaybackController') {
-        eventString = this._event.request.type.substring(19);
-    }
-
-    eventString += this.state;
-
-    if(this.listenerCount(eventString) < 1) {
-        eventString = 'Unhandled' + this.state;
-    }
-
-    if(this.listenerCount(eventString) < 1){
-        throw new Error(`No 'Unhandled' function defined for event: ${eventString}`);
-    }
-
-    this.emit(eventString);
-}
-
-function RegisterHandlers() {
-    for(var arg = 0; arg < arguments.length; arg++) {
-        var handlerObject = arguments[arg];
-
-        if(!isObject(handlerObject)) {
-            throw new Error(`Argument #${arg} was not an Object`);
-        }
-
-        var eventNames = Object.keys(handlerObject);
-
-        for(var i = 0; i < eventNames.length; i++) {
-            if(typeof(handlerObject[eventNames[i]]) !== 'function') {
-                throw new Error(`Event handler for '${eventNames[i]}' was not a function`);
-            }
-
-            var eventName = eventNames[i];
-
-            if(handlerObject[_StateString]) {
-                eventName += handlerObject[_StateString];
-            }
-
-            var localize = function() {
-                return this.i18n.t.apply(this.i18n, arguments);
-            };
-
-            var handlerContext = {
-                on: this.on.bind(this),
-                emit: this.emit.bind(this),
-                emitWithState: EmitWithState.bind(this),
-                state: this.state,
-                handler: this,
-                i18n: this.i18n,
-                locale: this.locale,
-                t : localize,
-                event: this._event,
-                attributes: this._event.session.attributes,
-                context: this._context,
-                name: eventName,
-                isOverridden:  IsOverridden.bind(this, eventName),
-                response: ResponseBuilder(this)
-            };
-
-            this.on(eventName, handlerObject[eventNames[i]].bind(handlerContext));
-        }
-    }
-}
+// class AlexaRequestEmitter extends EventEmitter {}
 
 function isObject(obj) {
-    return (!!obj) && (obj.constructor === Object);
+  return (!!obj) && (obj.constructor === Object);
 }
 
 function IsOverridden(name) {
-    return this.listenerCount(name) > 1;
-}
-
-function ResponseBuilder(self) {
-    var responseObject = self.response;
-    responseObject.version = '1.0';
-    responseObject.response = {
-        shouldEndSession: true
-    };
-    responseObject.sessionAttributes = self._event.session.attributes;
-
-    return (function () {
-        return {
-            'speak': function (speechOutput) {
-                responseObject.response.outputSpeech = createSSMLSpeechObject(speechOutput);
-                return this;
-            },
-            'listen': function (repromptSpeech) {
-                responseObject.response.reprompt = {
-                    outputSpeech: createSSMLSpeechObject(repromptSpeech)
-                };
-                responseObject.response.shouldEndSession = false;
-                return this;
-            },
-            'cardRenderer': function (cardTitle, cardContent, cardImage) {
-                var card = {
-                    type: 'Simple',
-                    title: cardTitle,
-                    content: cardContent
-                };
-
-                if(cardImage && (cardImage.smallImageUrl || cardImage.largeImageUrl)) {
-                    card.type = 'Standard';
-                    card['image'] = {};
-
-                    delete card.content;
-                    card.text = cardContent;
-
-                    if(cardImage.smallImageUrl) {
-                        card.image['smallImageUrl'] = cardImage.smallImageUrl;
-                    }
-
-                    if(cardImage.largeImageUrl) {
-                        card.image['largeImageUrl'] = cardImage.largeImageUrl;
-                    }
-                }
-
-                responseObject.response.card = card;
-                return this;
-            },
-            'linkAccountCard': function () {
-                responseObject.response.card = {
-                    type: 'LinkAccount'
-                };
-                return this;
-            },
-            'audioPlayer': function (directiveType, behavior, url, token, expectedPreviousToken, offsetInMilliseconds) {
-                var audioPlayerDirective;
-                if (directiveType === 'play') {
-                    audioPlayerDirective = {
-                        "type": "AudioPlayer.Play",
-                        "playBehavior": behavior,
-                        "audioItem": {
-                            "stream": {
-                                "url": url,
-                                "token": token,
-                                "expectedPreviousToken": expectedPreviousToken,
-                                "offsetInMilliseconds": offsetInMilliseconds
-                            }
-                        }
-                    };
-                } else if (directiveType === 'stop') {
-                    audioPlayerDirective = {
-                        "type": "AudioPlayer.Stop"
-                    };
-                } else {
-                    audioPlayerDirective = {
-                        "type": "AudioPlayer.Stop",
-                        "clearBehavior": behavior
-                    };
-                }
-
-                responseObject.response.directives = [audioPlayerDirective];
-                return this;
-            },
-            'audioPlayerPlay': function (behavior, url, token, expectedPreviousToken, offsetInMilliseconds) {
-                var audioPlayerDirective = {
-                    "type": "AudioPlayer.Play",
-                    "playBehavior": behavior,
-                    "audioItem": {
-                        "stream": {
-                            "url": url,
-                            "token": token,
-                            "expectedPreviousToken": expectedPreviousToken,
-                            "offsetInMilliseconds": offsetInMilliseconds
-                        }
-                    }
-                };
-
-                responseObject.response.directives = [audioPlayerDirective];
-                return this;
-            },
-            'audioPlayerStop': function () {
-                var audioPlayerDirective = {
-                    "type": "AudioPlayer.Stop"
-                };
-
-                responseObject.response.directives = [audioPlayerDirective];
-                return this;
-            },
-            'audioPlayerClearQueue': function (clearBehavior) {
-                var audioPlayerDirective = {
-                    "type": "AudioPlayer.ClearQueue",
-                    "clearBehavior": clearBehavior
-                };
-
-                responseObject.response.directives = [audioPlayerDirective];
-                return this;
-            }
-        }
-    })();
+  return this.listenerCount(name) > 1;
 }
 
 function createSSMLSpeechObject(message) {
+  return {
+    type: 'SSML',
+    ssml: `<speak> ${message} </speak>`,
+  };
+}
+
+function ResponseBuilder(self) {
+  const responseObject = self.response;
+  responseObject.version = '1.0';
+  responseObject.response = {
+    shouldEndSession: true,
+  };
+  responseObject.sessionAttributes = self._event.session.attributes;
+
+  return (function buildResponse() {
     return {
-        type: 'SSML',
-        ssml: `<speak> ${message} </speak>`
+      speak(speechOutput) {
+        responseObject.response.outputSpeech = createSSMLSpeechObject(speechOutput);
+        return this;
+      },
+      listen(repromptSpeech) {
+        responseObject.response.reprompt = {
+          outputSpeech: createSSMLSpeechObject(repromptSpeech),
+        };
+        responseObject.response.shouldEndSession = false;
+        return this;
+      },
+      cardRenderer(cardTitle, cardContent, cardImage) {
+        const card = {
+          type: 'Simple',
+          title: cardTitle,
+          content: cardContent,
+        };
+
+        if (cardImage && (cardImage.smallImageUrl || cardImage.largeImageUrl)) {
+          card.type = 'Standard';
+          card.image = {};
+
+          delete card.content;
+          card.text = cardContent;
+
+          if (cardImage.smallImageUrl) {
+            card.image.smallImageUrl = cardImage.smallImageUrl;
+          }
+
+          if (cardImage.largeImageUrl) {
+            card.image.largeImageUrl = cardImage.largeImageUrl;
+          }
+        }
+
+        responseObject.response.card = card;
+        return this;
+      },
+      linkAccountCard() {
+        responseObject.response.card = {
+          type: 'LinkAccount',
+        };
+        return this;
+      },
+      audioPlayer(directiveType, behavior, url, token, expectedPreviousToken, offsetInMilliseconds) {
+        let audioPlayerDirective;
+        if (directiveType === 'play') {
+          audioPlayerDirective = {
+            type: 'AudioPlayer.Play',
+            playBehavior: behavior,
+            audioItem: {
+              stream: {
+                url,
+                token,
+                expectedPreviousToken,
+                offsetInMilliseconds,
+              },
+            },
+          };
+        } else if (directiveType === 'stop') {
+          audioPlayerDirective = {
+            type: 'AudioPlayer.Stop',
+          };
+        } else {
+          audioPlayerDirective = {
+            type: 'AudioPlayer.Stop',
+            clearBehavior: behavior,
+          };
+        }
+
+        responseObject.response.directives = [audioPlayerDirective];
+        return this;
+      },
+      audioPlayerPlay(behavior, url, token, expectedPreviousToken, offsetInMilliseconds) {
+        const audioPlayerDirective = {
+          type: 'AudioPlayer.Play',
+          playBehavior: behavior,
+          audioItem: {
+            stream: {
+              url,
+              token,
+              expectedPreviousToken,
+              offsetInMilliseconds,
+            },
+          },
+        };
+
+        responseObject.response.directives = [audioPlayerDirective];
+        return this;
+      },
+      audioPlayerStop() {
+        const audioPlayerDirective = {
+          type: 'AudioPlayer.Stop',
+        };
+
+        responseObject.response.directives = [audioPlayerDirective];
+        return this;
+      },
+      audioPlayerClearQueue(clearBehavior) {
+        const audioPlayerDirective = {
+          type: 'AudioPlayer.ClearQueue',
+          clearBehavior,
+        };
+
+        responseObject.response.directives = [audioPlayerDirective];
+        return this;
+      },
     };
+  }());
 }
 
-function createStateHandler(state, obj){
-    if(!obj) {
-        obj = {};
+function createStateHandler(state, obj) {
+  let stateObj = obj;
+  if (!stateObj) {
+    stateObj = {};
+  }
+
+  Object.defineProperty(stateObj, _StateString, {
+    value: state || '',
+  });
+
+  return stateObj;
+}
+
+function EmitWithState(...args) {
+  const stateArgs = args;
+  if (arguments.length === 0) {
+    throw new Error('EmitWithState called without arguments');
+  }
+  stateArgs[0] = `stateArgs[0]${this.state}`;
+
+  if (this.listenerCount(stateArgs[0]) < 1) {
+    stateArgs[0] = `Unhandled${this.state}`;
+  }
+
+  if (this.listenerCount(stateArgs[0]) < 1) {
+    throw new Error(`No 'Unhandled' function defined for event: ${stateArgs[0]}`);
+  }
+
+  this.emit(...stateArgs);
+}
+
+function EmitEvent() {
+  this.state = this._event.session.attributes[_StateString] || '';
+
+  let eventString = '';
+
+  if (this._event.session.new && this.listenerCount(`NewSession${this.state}`) === 1) {
+    eventString = 'NewSession';
+  } else if (this._event.request.type === 'LaunchRequest') {
+    eventString = 'LaunchRequest';
+  } else if (this._event.request.type === 'IntentRequest') {
+    eventString = this._event.request.intent.name;
+  } else if (this._event.request.type === 'SessionEndedRequest') {
+    eventString = 'SessionEndedRequest';
+  } else if (this._event.request.type.substring(0, 11) === 'AudioPlayer') {
+    eventString = this._event.request.type.substring(12);
+  } else if (this._event.request.type.substring(0, 18) === 'PlaybackController') {
+    eventString = this._event.request.type.substring(19);
+  }
+
+  eventString += this.state;
+
+  if (this.listenerCount(eventString) < 1) {
+    eventString = `Unhandled${this.state}`;
+  }
+
+  if (this.listenerCount(eventString) < 1) {
+    throw new Error(`No 'Unhandled' function defined for event: ${eventString}`);
+  }
+
+  this.emit(eventString);
+}
+
+function ValidateRequest() {
+  const event = this._event;
+  const context = this._context;
+  const handlerAppId = this.appId;
+
+  let requestAppId = '';
+  let userId = '';
+
+  // Long-form audio enabled skills use event.context
+  if (event.context) {
+    requestAppId = event.context.System.application.applicationId;
+    userId = event.context.System.user.userId;
+  } else if (event.session) {
+    requestAppId = event.session.application.applicationId;
+    userId = event.session.user.userId;
+  }
+
+
+  if (!handlerAppId) {
+    console.log('Warning: Application ID is not set');
+  }
+
+  try {
+    // Validate that this request originated from authorized source.
+    if (handlerAppId && (requestAppId !== handlerAppId)) {
+      console.log(`The applicationIds don't match: ${requestAppId} and ${handlerAppId}`);
+      context.fail(`Invalid ApplicationId: ${handlerAppId}`);
+      return;
     }
 
-    Object.defineProperty(obj, _StateString, {
-        value: state || ''
+    if (this.dynamoDBTableName && (!event.session.sessionId || event.session.new)) {
+      attributesHelper.get(this.dynamoDBTableName, userId, (err, data) => {
+        if (err) {
+          context.fail(`Error fetching user state: ${err}`);
+          return;
+        }
+        Object.assign(this._event.session.attributes, data);
+      });
+    }
+    EmitEvent.call(this);
+  } catch (e) {
+    console.log(`Unexpected exception '${e}':\n${e.stack}`);
+    context.fail(e);
+  }
+}
+
+function HandleLambdaEvent() {
+  this.locale = this._event.request.locale;
+  if (this.resources) {
+    this.i18n.use(sprintf).init({
+      overloadTranslationOptionHandler: sprintf.overloadTranslationOptionHandler,
+      returnObjects: true,
+      lng: this.locale,
+      resources: this.resources,
+    }, (err) => {
+      if (err) {
+        throw new Error(`Error initializing i18next: ${err}`);
+      }
+      ValidateRequest.call(this);
     });
-
-    return obj;
+  } else {
+    ValidateRequest.call(this);
+  }
 }
 
-function EmitWithState() {
-    if(arguments.length === 0) {
-        throw new Error('EmitWithState called without arguments');
-    }
-    arguments[0] = arguments[0] + this.state;
+function RegisterHandlers(...args) {
+  for (let arg = 0; arg < args.length; arg += 1) {
+    const handlerObject = args[arg];
 
-    if (this.listenerCount(arguments[0]) < 1) {
-        arguments[0] = 'Unhandled' + this.state;
+    if (!isObject(handlerObject)) {
+      throw new Error(`Argument #${arg} was not an Object`);
     }
 
-    if (this.listenerCount(arguments[0]) < 1) {
-        throw new Error(`No 'Unhandled' function defined for event: ${arguments[0]}`);
-    }
+    const eventNames = Object.keys(handlerObject);
 
-    this.emit.apply(this, arguments);
+    for (let i = 0; i < eventNames.length; i += 1) {
+      if (typeof (handlerObject[eventNames[i]]) !== 'function') {
+        throw new Error(`Event handler for '${eventNames[i]}' was not a function`);
+      }
+
+      let eventName = eventNames[i];
+
+      if (handlerObject[_StateString]) {
+        eventName += handlerObject[_StateString];
+      }
+
+      const localize = function localize(...localizeArgs) {
+        return this.i18n.t(...localizeArgs);
+      };
+
+      const handlerContext = {
+        on: this.on.bind(this),
+        emit: this.emit.bind(this),
+        emitWithState: EmitWithState.bind(this),
+        state: this.state,
+        handler: this,
+        i18n: this.i18n,
+        locale: this.locale,
+        t: localize,
+        event: this._event,
+        attributes: this._event.session.attributes,
+        context: this._context,
+        name: eventName,
+        isOverridden: IsOverridden.bind(this, eventName),
+        response: ResponseBuilder(this),
+      };
+
+      this.on(eventName, handlerObject[eventNames[i]].bind(handlerContext));
+    }
+  }
 }
 
-process.on('uncaughtException', function(err) {
-    console.log(`Uncaught exception: ${err}\n${err.stack}`);
-    throw err;
-});
+function alexaRequestHandler(event, context, callback) {
+  const newEvent = event;
+  if (!newEvent.session) {
+    newEvent.session = { attributes: {} };
+  } else if (!event.session.attributes) {
+    newEvent.session.attributes = {};
+  }
+
+  const handler = new AlexaRequestEmitter();
+  handler.setMaxListeners(Infinity);
+
+  Object.defineProperty(handler, '_event', {
+    value: newEvent,
+    writable: false,
+  });
+
+  Object.defineProperty(handler, '_context', {
+    value: context,
+    writable: false,
+  });
+
+  Object.defineProperty(handler, '_callback', {
+    value: callback,
+    writable: false,
+  });
+
+  Object.defineProperty(handler, 'state', {
+    value: null,
+    writable: true,
+    configurable: true,
+  });
+
+  Object.defineProperty(handler, 'appId', {
+    value: null,
+    writable: true,
+  });
+
+  Object.defineProperty(handler, 'response', {
+    value: {},
+    writable: true,
+  });
+
+  Object.defineProperty(handler, 'dynamoDBTableName', {
+    value: null,
+    writable: true,
+  });
+
+  Object.defineProperty(handler, 'saveBeforeResponse', {
+    value: false,
+    writable: true,
+  });
+
+  Object.defineProperty(handler, 'i18n', {
+    value: i18n,
+    writable: true,
+  });
+
+  Object.defineProperty(handler, 'locale', {
+    value: undefined,
+    writable: true,
+  });
+
+  Object.defineProperty(handler, 'resources', {
+    value: undefined,
+    writable: true,
+  });
+
+  Object.defineProperty(handler, 'registerHandlers', {
+    value: function registerHandlers(...args) {
+      RegisterHandlers.apply(handler, args);
+    },
+    writable: false,
+  });
+
+  Object.defineProperty(handler, 'execute', {
+    value: function execute() {
+      HandleLambdaEvent.call(handler);
+    },
+    writable: false,
+  });
+
+  handler.registerHandlers(responseHandlers);
+
+  return handler;
+}
 
 module.exports.LambdaHandler = alexaRequestHandler;
 module.exports.CreateStateHandler = createStateHandler;

--- a/lib/alexa.js
+++ b/lib/alexa.js
@@ -108,6 +108,7 @@ function alexaRequestHandler(event, context, callback) {
     value: function t(...args) {
       return this.i18n.t(...args);
     },
+    writable: false,
   });
 
   handler.registerHandlers(responseHandlers);

--- a/lib/alexa.js
+++ b/lib/alexa.js
@@ -1,7 +1,7 @@
 'use strict';
 
+
 const EventEmitter = require('events').EventEmitter;
-const util = require('util');
 const i18n = require('i18next');
 const sprintf = require('i18next-sprintf-postprocessor');
 const attributesHelper = require('./DynamoAttributesHelper');
@@ -9,16 +9,42 @@ const responseHandlers = require('./response');
 
 const _StateString = 'STATE';
 
+
 class AlexaRequestEmitter extends EventEmitter {}
 
+/**
+ * isObject - Detect whether parameter is an object
+ *
+ * @param  {Object}  obj Object to check
+ * @return {boolean}     If obj is an object
+ */
 function isObject(obj) {
   return (!!obj) && (obj.constructor === Object);
 }
 
+/**
+ * IsOverridden - Detect whether one of the inbuilt listeners is overridden.
+ *
+ * NB:  Cannot itself differentiate between overridden and overriding event.
+ *      This simply checks if there's more than one listener.
+ *
+ * @param  {string} name     Event name to be checked
+ * @return {boolean}         If there is more than one listener for the event name
+ */
 function IsOverridden(name) {
   return this.listenerCount(name) > 1;
 }
 
+
+/**
+ * createSSMLSpeechObject - Form SSML Object from string.
+ *                          String is wrapped in <speak> tags.
+ *
+ * NB: Cannot detect SSML-specific characters, so they must be escaped with backslash.
+ *
+ * @param  {string} message String to wrap
+ * @return {Object}         SSML object containing wrapped string
+ */
 function createSSMLSpeechObject(message) {
   return {
     type: 'SSML',
@@ -26,6 +52,12 @@ function createSSMLSpeechObject(message) {
   };
 }
 
+/**
+ * ResponseBuilder - Form closure used to manually build responses.
+ *
+ * @param  {Object} self  Object to take response from, and set response too
+ * @return {Object}       Object with methods to create your own response
+ */
 function ResponseBuilder(self) {
   const responseObject = self.response;
   responseObject.version = '1.0';
@@ -36,10 +68,25 @@ function ResponseBuilder(self) {
 
   return (function buildResponse() {
     return {
+
+      /**
+       * speak - Set speechOutput of responseObject to given string
+       *
+       * @param  {string} speechOutput  String to output
+       * @return {Object}               this, to make methods chainable
+       */
       speak(speechOutput) {
         responseObject.response.outputSpeech = createSSMLSpeechObject(speechOutput);
         return this;
       },
+
+      /**
+       * listen - Set repromptSpeech of responseObject to given string.
+       *          Set shouldEndSession to false.
+       *
+       * @param  {string} repromptSpeech  String to remprompt
+       * @return {Object}                 this, to make methods chainable
+       */
       listen(repromptSpeech) {
         responseObject.response.reprompt = {
           outputSpeech: createSSMLSpeechObject(repromptSpeech),
@@ -47,6 +94,15 @@ function ResponseBuilder(self) {
         responseObject.response.shouldEndSession = false;
         return this;
       },
+
+      /**
+       * cardRenderer - Set card property of responseObject using parameters
+       *
+       * @param  {string} cardTitle   Title of card
+       * @param  {string} cardContent Content of card
+       * @param  {Object} cardImage   Image object for card
+       * @return {Object}             this, to make methods chainable
+       */
       cardRenderer(cardTitle, cardContent, cardImage) {
         const card = {
           type: 'Simple',
@@ -73,12 +129,30 @@ function ResponseBuilder(self) {
         responseObject.response.card = card;
         return this;
       },
+
+      /**
+       * linkAccountCard - Set type of card property to Link Account Card.
+       *
+       * @return {Object}  this, to make functions chainable
+       */
       linkAccountCard() {
         responseObject.response.card = {
           type: 'LinkAccount',
         };
         return this;
       },
+
+      /**
+       * audioPlayer - Set up audio player directive, using any directive type.
+       *
+       * @param  {string} directiveType         Type of directive: either 'play', 'stop', or 'clearqueue'
+       * @param  {string} behavior              Playback behaviour: either 'REPLACE_ALL', 'ENQUEUE', or 'REPLACE_ENQUEUED'
+       * @param  {string} url                   URL of audio stream
+       * @param  {string} token                 Opaque token representing audio stream
+       * @param  {string} expectedPreviousToken Opaque token representing previous audio stream
+       * @param  {string} offsetInMilliseconds  Timestamp at which Alexa should start playback
+       * @return {Object}                       this, to make functions chainable
+       */
       audioPlayer(directiveType, behavior, url, token, expectedPreviousToken, offsetInMilliseconds) {
         let audioPlayerDirective;
         if (directiveType === 'play') {
@@ -100,7 +174,7 @@ function ResponseBuilder(self) {
           };
         } else {
           audioPlayerDirective = {
-            type: 'AudioPlayer.Stop',
+            type: 'AudioPlayer.ClearQueue',
             clearBehavior: behavior,
           };
         }
@@ -108,6 +182,17 @@ function ResponseBuilder(self) {
         responseObject.response.directives = [audioPlayerDirective];
         return this;
       },
+
+      /**
+       * audioPlayerPlay - Set up audio player directive, using 'AudioPlayer.Play' directive type.
+       *
+       * @param  {string} behavior              Playback behaviour: either 'REPLACE_ALL', 'ENQUEUE', or 'REPLACE_ENQUEUED'
+       * @param  {string} url                   URL of audio stream
+       * @param  {string} token                 Opaque token representing audio stream
+       * @param  {string} expectedPreviousToken Opaque token representing previous audio stream
+       * @param  {string} offsetInMilliseconds  Timestamp at which Alexa should start playback
+       * @return {Object}                       this, to make functions chainable
+       */
       audioPlayerPlay(behavior, url, token, expectedPreviousToken, offsetInMilliseconds) {
         const audioPlayerDirective = {
           type: 'AudioPlayer.Play',
@@ -125,6 +210,12 @@ function ResponseBuilder(self) {
         responseObject.response.directives = [audioPlayerDirective];
         return this;
       },
+
+      /**
+       * audioPlayerStop - Set up audio player directive, using 'AudioPlayer.Stop' as directive type.
+       *
+       * @return {Object} this, to make functions chainable
+       */
       audioPlayerStop() {
         const audioPlayerDirective = {
           type: 'AudioPlayer.Stop',
@@ -133,6 +224,13 @@ function ResponseBuilder(self) {
         responseObject.response.directives = [audioPlayerDirective];
         return this;
       },
+
+      /**
+       * audioPlayerClearQueue - Set up audio player directive, using 'AudioPlayer.ClearQueue' as directive type.
+       *
+       * @param  {string} clearBehavior Clear Behaviour: either 'CLEAR_ENQUEUED' or 'CLEAR_ALL'
+       * @return {Object}               this, to make functions chainable
+       */
       audioPlayerClearQueue(clearBehavior) {
         const audioPlayerDirective = {
           type: 'AudioPlayer.ClearQueue',
@@ -146,6 +244,16 @@ function ResponseBuilder(self) {
   }());
 }
 
+
+/**
+ * createStateHandler - Make a handler, and sets its _StateString property.
+ *
+ * _StateString is detected by RegisterHandlers and appended to all event names.
+ *
+ * @param  {string} state State to become _StateString
+ * @param  {Object} obj   Handler object
+ * @return {Object}       Handler with _StateString property
+ */
 function createStateHandler(state, obj) {
   let stateObj = obj;
   if (!stateObj) {
@@ -159,24 +267,43 @@ function createStateHandler(state, obj) {
   return stateObj;
 }
 
-function EmitWithState(...args) {
-  const stateArgs = args;
-  if (arguments.length === 0) {
-    throw new Error('EmitWithState called without arguments');
-  }
-  stateArgs[0] = `stateArgs[0]${this.state}`;
 
-  if (this.listenerCount(stateArgs[0]) < 1) {
-    stateArgs[0] = `Unhandled${this.state}`;
+/**
+ * EmitWithState - Emit intent to any state handler, using this.handler.state as state
+ *
+ * NB: Must be bound to correct handler.
+ *
+ * @param  {string} intent   Name of 'intent' event to emit
+ * @param  {...Object} args  Other arguments to be emitted.
+ * @return {undefined}
+ */
+function EmitWithState(intent, ...args) {
+  let stateIntent = intent;
+  if (!intent) {
+    throw new Error('EmitWithState called without intent');
+  }
+  stateIntent = `${stateIntent}${this.state}`;
+
+  if (this.listenerCount(stateIntent) < 1) {
+    stateIntent = `Unhandled${this.state}`;
   }
 
-  if (this.listenerCount(stateArgs[0]) < 1) {
-    throw new Error(`No 'Unhandled' function defined for event: ${stateArgs[0]}`);
+  if (this.listenerCount(stateIntent) < 1) {
+    throw new Error(`No 'Unhandled' function defined for event: ${stateIntent}`);
   }
 
-  this.emit(...stateArgs);
+  this.emit(stateIntent, args);
 }
 
+
+/**
+ * EmitEvent - Parse lambda event and emit correct event string to handler.
+ *
+ * NB: this keyword must be bound to handler object.
+ *
+ * @fires eventString
+ * @return {undefined}
+ */
 function EmitEvent() {
   this.state = this._event.session.attributes[_StateString] || '';
 
@@ -209,6 +336,14 @@ function EmitEvent() {
   this.emit(eventString);
 }
 
+
+/**
+ * ValidateRequest - Check that App IDs match, get attributes from DynamoDB, then call EmitEvent.
+ *
+ * NB: this keyword must be bound to handler object.
+ *
+ * @return {undefined}
+ */
 function ValidateRequest() {
   const event = this._event;
   const context = this._context;
@@ -225,7 +360,6 @@ function ValidateRequest() {
     requestAppId = event.session.application.applicationId;
     userId = event.session.user.userId;
   }
-
 
   if (!handlerAppId) {
     console.log('Warning: Application ID is not set');
@@ -255,6 +389,14 @@ function ValidateRequest() {
   }
 }
 
+
+/**
+ * HandleLambdaEvent - Set up i18next translation backend, then call ValidateRequest.
+ *
+ * NB: this keyword must be bound to handler object.
+ *
+ * @return {undefined}
+ */
 function HandleLambdaEvent() {
   this.locale = this._event.request.locale;
   if (this.resources) {
@@ -274,6 +416,15 @@ function HandleLambdaEvent() {
   }
 }
 
+
+/**
+ * RegisterHandlers - Add all handlers to this, adding events for each property.
+ *
+ * NB: this keyword must be bound to handler object.
+ *
+ * @param  {...Object} args  Array of all handlers to register
+ * @return {undefined}
+ */
 function RegisterHandlers(...args) {
   for (let arg = 0; arg < args.length; arg += 1) {
     const handlerObject = args[arg];
@@ -299,6 +450,9 @@ function RegisterHandlers(...args) {
         return this.i18n.t(...localizeArgs);
       };
 
+      /**
+       * Context that registered handlers are bound too.
+       */
       const handlerContext = {
         on: this.on.bind(this),
         emit: this.emit.bind(this),
@@ -321,6 +475,16 @@ function RegisterHandlers(...args) {
   }
 }
 
+
+/**
+ * alexaRequestHandler - Make handler object, and register built-in events from response.js
+ * Handler object extends EventEmitter.
+ *
+ * @param  {Object} event    Lambda event (request body)
+ * @param  {Object} context  Lambda context
+ * @param  {Object} callback Lambda callback
+ * @return {Object}          AlexaRequestEmitter with preregistered events registered.
+ */
 function alexaRequestHandler(event, context, callback) {
   const newEvent = event;
   if (!newEvent.session) {

--- a/lib/alexa.js
+++ b/lib/alexa.js
@@ -242,24 +242,22 @@ function EmitEvent() {
  * @return {undefined}
  */
 function RegisterHandlers(...args) {
-  for (let arg = 0; arg < args.length; arg += 1) {
-    const handlerObject = args[arg];
-
+  args.forEach((handlerObject) => {
     if (!isObject(handlerObject)) {
-      throw new Error(`Argument #${arg} was not an Object`);
+      throw new Error(`Argument #${args.indexOf(handlerObject)} was not an Object.`);
     }
 
     const eventNames = Object.keys(handlerObject);
 
-    for (let i = 0; i < eventNames.length; i += 1) {
-      if (typeof (handlerObject[eventNames[i]]) !== 'function') {
-        throw new Error(`Event handler for '${eventNames[i]}' was not a function`);
+    eventNames.forEach((eventName) => {
+      let stateEventName = eventName;
+
+      if (typeof (handlerObject[eventName]) !== 'function') {
+        throw new Error(`Event handler for '${eventName}' was not a function`);
       }
 
-      let eventName = eventNames[i];
-
       if (handlerObject[_StateString]) {
-        eventName += handlerObject[_StateString];
+        stateEventName += handlerObject[_StateString];
       }
 
       /**
@@ -277,14 +275,14 @@ function RegisterHandlers(...args) {
         event: this._event,
         attributes: this._event.session.attributes,
         context: this._context,
-        name: eventName,
-        isOverridden: IsOverridden.bind(this, eventName),
+        name: stateEventName,
+        isOverridden: IsOverridden.bind(this, stateEventName),
         response: responseBuilder(this),
       };
 
-      this.on(eventName, handlerObject[eventNames[i]].bind(handlerContext));
-    }
-  }
+      this.on(stateEventName, handlerObject[eventName].bind(handlerContext));
+    });
+  });
 }
 
 /**

--- a/lib/response.js
+++ b/lib/response.js
@@ -76,19 +76,19 @@ module.exports = (function() {
     /**
      * tellWithPermissionCard - Emit speech output, and card requesting permissions to Alexa. End session.
      *
-     * @param  {type} speechOutput Speech Output to emit
-     * @param  {type} permissions  List of scope strings to request
+     * @param  {string} speechOutput   Speech Output to emit
+     * @param  {string[]} permissions  List of scope strings to request
      * @return {undefined}
      */
-    ':tellWithPermissionCard': function(speechOutput, permissions) {
-      if(this.isOverridden()) {
+    ':tellWithPermissionCard': function tellWithPermissionCard(speechOutput, permissions) {
+      if (this.isOverridden()) {
         return;
       }
 
       this.handler.response = buildSpeechletResponse({
         sessionAttributes: this.attributes,
         output: getSSMLResponse(speechOutput),
-        permissions: permissions,
+        permissions,
         cardType: 'AskForPermissionsConsent',
         shouldEndSession: true,
       });
@@ -303,7 +303,7 @@ function buildSpeechletResponse(options) {
       if (options.cardImage.smallImageUrl) {
         alexaResponse.card.image.smallImageUrl = options.cardImage.smallImageUrl;
       }
-      if(options.cardImage.largeImageUrl) {
+      if (options.cardImage.largeImageUrl) {
         alexaResponse.card.image.largeImageUrl = options.cardImage.largeImageUrl;
       }
     }

--- a/lib/response.js
+++ b/lib/response.js
@@ -1,224 +1,224 @@
 'use strict';
-var attributesHelper = require('./DynamoAttributesHelper');
 
-module.exports = (function () {
-    return {
-        ':tell': function (speechOutput) {
-            if(this.isOverridden()) {
-                return;
-            }
-
-            this.handler.response = buildSpeechletResponse({
-                sessionAttributes: this.attributes,
-                output: getSSMLResponse(speechOutput),
-                shouldEndSession: true
-            });
-            this.emit(':responseReady');
-        },
-        ':ask': function (speechOutput, repromptSpeech) {
-            if(this.isOverridden()) {
-                return;
-            }
-            this.handler.response = buildSpeechletResponse({
-                sessionAttributes: this.attributes,
-                output: getSSMLResponse(speechOutput),
-                reprompt: getSSMLResponse(repromptSpeech),
-                shouldEndSession: false
-            });
-            this.emit(':responseReady');
-        },
-        ':askWithCard': function(speechOutput, repromptSpeech, cardTitle, cardContent, imageObj) {
-            if(this.isOverridden()) {
-                return;
-            }
-
-            this.handler.response = buildSpeechletResponse({
-                sessionAttributes: this.attributes,
-                output: getSSMLResponse(speechOutput),
-                reprompt: getSSMLResponse(repromptSpeech),
-                cardTitle: cardTitle,
-                cardContent: cardContent,
-                cardImage: imageObj,
-                shouldEndSession: false
-            });
-            this.emit(':responseReady');
-        },
-        ':tellWithCard': function(speechOutput, cardTitle, cardContent, imageObj) {
-            if(this.isOverridden()) {
-                return;
-            }
-
-            this.handler.response = buildSpeechletResponse({
-                sessionAttributes: this.attributes,
-                output: getSSMLResponse(speechOutput),
-                cardTitle: cardTitle,
-                cardContent: cardContent,
-                cardImage: imageObj,
-                shouldEndSession: true
-            });
-            this.emit(':responseReady');
-        },
-        ':tellWithLinkAccountCard': function(speechOutput) {
-            if(this.isOverridden()) {
-                return;
-            }
-
-            this.handler.response = buildSpeechletResponse({
-                sessionAttributes: this.attributes,
-                output: getSSMLResponse(speechOutput),
-                cardType: 'LinkAccount',
-                shouldEndSession: true
-            });
-            this.emit(':responseReady');
-        },
-        ':askWithLinkAccountCard': function(speechOutput, repromptSpeech) {
-            if(this.isOverridden()) {
-                return;
-            }
-
-            this.handler.response = buildSpeechletResponse({
-                sessionAttributes: this.attributes,
-                output: getSSMLResponse(speechOutput),
-                reprompt: getSSMLResponse(repromptSpeech),
-                cardType: 'LinkAccount',
-                shouldEndSession: false
-            });
-            this.emit(':responseReady');
-        },
-        ':responseReady': function () {
-            if (this.isOverridden()) {
-                return;
-            }
-
-            if(this.handler.state) {
-                this.handler.response.sessionAttributes['STATE'] = this.handler.state;
-            }
-
-            if (this.handler.dynamoDBTableName) {
-                return this.emit(':saveState');
-            }
-
-            this.context.succeed(this.handler.response);
-        },
-        ':saveState': function(forceSave) {
-            if (this.isOverridden()) {
-                return;
-            }
-
-            if(forceSave && this.handler.state){
-                this.attributes['STATE'] = this.handler.state;
-            }
-
-            var userId = '';
-
-            // Long-form audio enabled skills use event.context
-            if (this.event.context) {
-                userId = this.event.context.System.user.userId;
-            } else if (this.event.session) {
-                userId = this.event.session.user.userId;
-            }
-
-            if(this.saveBeforeResponse || forceSave || this.handler.response.response.shouldEndSession) {
-                attributesHelper.set(this.handler.dynamoDBTableName, userId, this.attributes,
-                    (err) => {
-                        if(err) {
-                            return this.emit(':saveStateError', err);
-                        }
-
-                        // To save the state when AudioPlayer Requests come without sending a response.
-                        if (Object.keys(this.handler.response).length === 0 && this.handler.response.constructor === Object) {
-                            this.handler.response =  true;
-                        }
-
-                        this.context.succeed(this.handler.response);
-                    });
-            } else {
-                this.context.succeed(this.handler.response || true);
-            }
-        },
-        ':saveStateError': function(err) {
-            if(this.isOverridden()) {
-                return;
-            }
-            console.log(`Error saving state: ${err}\n${err.stack}`);
-            this.context.fail(err);
-        }
-    };
-})();
-
-function createSpeechObject(optionsParam) {
-    if (optionsParam && optionsParam.type === 'SSML') {
-        return {
-            type: optionsParam.type,
-            ssml: optionsParam['speech']
-        };
-    } else {
-        return {
-            type: optionsParam.type || 'PlainText',
-            text: optionsParam['speech'] || optionsParam
-        };
-    }
-}
-
-function buildSpeechletResponse(options) {
-    var alexaResponse = {
-        outputSpeech: createSpeechObject(options.output),
-        shouldEndSession: options.shouldEndSession
-    };
-
-    if (options.reprompt) {
-        alexaResponse.reprompt = {
-            outputSpeech: createSpeechObject(options.reprompt)
-        };
-    }
-
-    if (options.cardTitle && options.cardContent) {
-        alexaResponse.card = {
-            type: 'Simple',
-            title: options.cardTitle,
-            content: options.cardContent
-        };
-
-        if(options.cardImage && (options.cardImage.smallImageUrl || options.cardImage.largeImageUrl)) {
-            alexaResponse.card.type = 'Standard';
-            alexaResponse.card['image'] = {};
-
-            delete alexaResponse.card.content;
-            alexaResponse.card.text = options.cardContent;
-
-            if(options.cardImage.smallImageUrl) {
-                alexaResponse.card.image['smallImageUrl'] = options.cardImage.smallImageUrl;
-            }
-
-            if(options.cardImage.largeImageUrl) {
-                alexaResponse.card.image['largeImageUrl'] = options.cardImage.largeImageUrl;
-            }
-        }
-    } else if (options.cardType === 'LinkAccount') {
-        alexaResponse.card = {
-            type: 'LinkAccount'
-        };
-    }
-
-    var returnResult = {
-        version: '1.0',
-        response: alexaResponse
-    };
-
-    if (options.sessionAttributes) {
-        returnResult.sessionAttributes = options.sessionAttributes;
-    }
-    return returnResult;
-}
+const attributesHelper = require('./DynamoAttributesHelper');
 
 // TODO: check for ssml content in card
 function getSSMLResponse(message) {
-    if (message == null) {
-        return null;
-    } else {
-        return {
-            type: 'SSML',
-            speech: `<speak> ${message} </speak>`
-        };
-    }
+  if (message == null) {
+    return null;
+  }
+  return {
+    type: 'SSML',
+    speech: `<speak> ${message} </speak>`,
+  };
 }
+
+function createSpeechObject(optionsParam) {
+  if (optionsParam && optionsParam.type === 'SSML') {
+    return {
+      type: optionsParam.type,
+      ssml: optionsParam.speech,
+    };
+  }
+  return {
+    type: optionsParam.type || 'PlainText',
+    text: optionsParam.speech || optionsParam,
+  };
+}
+
+function buildSpeechletResponse(options) {
+  const alexaResponse = {
+    outputSpeech: createSpeechObject(options.output),
+    shouldEndSession: options.shouldEndSession,
+  };
+
+  if (options.reprompt) {
+    alexaResponse.reprompt = {
+      outputSpeech: createSpeechObject(options.reprompt),
+    };
+  }
+
+  if (options.cardTitle && options.cardContent) {
+    alexaResponse.card = {
+      type: 'Simple',
+      title: options.cardTitle,
+      content: options.cardContent,
+    };
+
+    if (options.cardImage && (options.cardImage.smallImageUrl || options.cardImage.largeImageUrl)) {
+      alexaResponse.card.type = 'Standard';
+      alexaResponse.card.image = {};
+
+      delete alexaResponse.card.content;
+      alexaResponse.card.text = options.cardContent;
+
+      if (options.cardImage.smallImageUrl) {
+        alexaResponse.card.image.smallImageUrl = options.cardImage.smallImageUrl;
+      }
+
+      if (options.cardImage.largeImageUrl) {
+        alexaResponse.card.image.largeImageUrl = options.cardImage.largeImageUrl;
+      }
+    }
+  } else if (options.cardType === 'LinkAccount') {
+    alexaResponse.card = {
+      type: 'LinkAccount',
+    };
+  }
+
+  const returnResult = {
+    version: '1.0',
+    response: alexaResponse,
+  };
+
+  if (options.sessionAttributes) {
+    returnResult.sessionAttributes = options.sessionAttributes;
+  }
+  return returnResult;
+}
+
+module.exports = (function exported() {
+  return {
+    ':tell': function tell(speechOutput) {
+      if (this.isOverridden()) {
+        return;
+      }
+
+      this.handler.response = buildSpeechletResponse({
+        sessionAttributes: this.attributes,
+        output: getSSMLResponse(speechOutput),
+        shouldEndSession: true,
+      });
+      this.emit(':responseReady');
+    },
+    ':ask': function ask(speechOutput, repromptSpeech) {
+      if (this.isOverridden()) {
+        return;
+      }
+      this.handler.response = buildSpeechletResponse({
+        sessionAttributes: this.attributes,
+        output: getSSMLResponse(speechOutput),
+        reprompt: getSSMLResponse(repromptSpeech),
+        shouldEndSession: false,
+      });
+      this.emit(':responseReady');
+    },
+    ':askWithCard': function askWithCard(speechOutput, repromptSpeech, cardTitle, cardContent, imageObj) {
+      if (this.isOverridden()) {
+        return;
+      }
+
+      this.handler.response = buildSpeechletResponse({
+        sessionAttributes: this.attributes,
+        output: getSSMLResponse(speechOutput),
+        reprompt: getSSMLResponse(repromptSpeech),
+        cardTitle,
+        cardContent,
+        cardImage: imageObj,
+        shouldEndSession: false,
+      });
+      this.emit(':responseReady');
+    },
+    ':tellWithCard': function tellWithCard(speechOutput, cardTitle, cardContent, imageObj) {
+      if (this.isOverridden()) {
+        return;
+      }
+
+      this.handler.response = buildSpeechletResponse({
+        sessionAttributes: this.attributes,
+        output: getSSMLResponse(speechOutput),
+        cardTitle,
+        cardContent,
+        cardImage: imageObj,
+        shouldEndSession: true,
+      });
+      this.emit(':responseReady');
+    },
+    ':tellWithLinkAccountCard': function tellWithLinkAccountCard(speechOutput) {
+      if (this.isOverridden()) {
+        return;
+      }
+
+      this.handler.response = buildSpeechletResponse({
+        sessionAttributes: this.attributes,
+        output: getSSMLResponse(speechOutput),
+        cardType: 'LinkAccount',
+        shouldEndSession: true,
+      });
+      this.emit(':responseReady');
+    },
+    ':askWithLinkAccountCard': function askWithLinkAccountCard(speechOutput, repromptSpeech) {
+      if (this.isOverridden()) {
+        return;
+      }
+
+      this.handler.response = buildSpeechletResponse({
+        sessionAttributes: this.attributes,
+        output: getSSMLResponse(speechOutput),
+        reprompt: getSSMLResponse(repromptSpeech),
+        cardType: 'LinkAccount',
+        shouldEndSession: false,
+      });
+      this.emit(':responseReady');
+    },
+    ':responseReady': function responseReady() {
+      if (this.isOverridden()) {
+        return;
+      }
+
+      if (this.handler.state) {
+        this.handler.response.sessionAttributes.STATE = this.handler.state;
+      }
+
+      if (this.handler.dynamoDBTableName) {
+        this.emit(':saveState');
+        return;
+      }
+
+      this.context.succeed(this.handler.response);
+    },
+    ':saveState': function saveState(forceSave) {
+      let userId = '';
+      if (this.isOverridden()) {
+        return;
+      }
+
+      if (forceSave && this.handler.state) {
+        this.attributes.STATE = this.handler.state;
+      }
+
+      // Long-form audio enabled skills use event.context
+      if (this.event.context) {
+        userId = this.event.context.System.user.userId;
+      } else if (this.event.session) {
+        userId = this.event.session.user.userId;
+      }
+
+      if (this.saveBeforeResponse || forceSave || this.handler.response.response.shouldEndSession) {
+        attributesHelper.set(this.handler.dynamoDBTableName, userId, this.attributes,
+          (err) => {
+            if (err) {
+              this.emit(':saveStateError', err);
+              return;
+            }
+
+            // To save the state when AudioPlayer Requests come without sending a response.
+            if (Object.keys(this.handler.response).length === 0 && this.handler.response.constructor === Object) {
+              this.handler.response = true;
+            }
+
+            this.context.succeed(this.handler.response);
+          });
+      } else {
+        this.context.succeed(this.handler.response || true);
+      }
+    },
+    ':saveStateError': function saveStateError(err) {
+      if (this.isOverridden()) {
+        return;
+      }
+      console.log(`Error saving state: ${err}\n${err.stack}`);
+      this.context.fail(err);
+    },
+  };
+}());

--- a/lib/response.js
+++ b/lib/response.js
@@ -103,8 +103,8 @@ module.exports = (function exported() {
      * tell - Emit speechOutput to Alexa. End session.
      *        Can be overridden.
      *
-     * @param  {string} speechOutput    Speech Output to emit
-     * @return {undefined}              description
+     * @param  {string} speechOutput  Speech Output to emit
+     * @return {undefined}
      */
     ':tell': function tell(speechOutput) {
       if (this.isOverridden()) {

--- a/lib/response.js
+++ b/lib/response.js
@@ -2,102 +2,7 @@
 
 const attributesHelper = require('./DynamoAttributesHelper');
 
-/**
- * getSSMLResponse - Form SSML Object from string.
- * String is wrapped in <speak> tags.
- *
- * NB: Cannot detect SSML-specific characters, so they must be escaped with backslash.
- *
- * @param  {string} message String to wrap
- * @return {Object}         SSML object containing wrapped string
- */
-function getSSMLResponse(message) {
-  if (message == null) {
-    return null;
-  }
-  return {
-    type: 'SSML',
-    speech: `<speak> ${message} </speak>`,
-  };
-}
-
-/**
- * createSpeechObject - Form SSML object from parameter object.
- *
- * @param  {Object} optionsParam  Object with 'type' and 'speech' properties.
- * @return {Object}               SSML object containg message.
- */
-function createSpeechObject(optionsParam) {
-  if (optionsParam && optionsParam.type === 'SSML') {
-    return {
-      type: optionsParam.type,
-      ssml: optionsParam.speech,
-    };
-  }
-  return {
-    type: optionsParam.type || 'PlainText',
-    text: optionsParam.speech || optionsParam,
-  };
-}
-
-/**
- * buildSpeechletResponse - Generate full speechlet response using options object.
- *
- * @param  {type} options Object with properties to use in response.
- * @return {type}         Response object with all parameters
- */
-function buildSpeechletResponse(options) {
-  const alexaResponse = {
-    outputSpeech: createSpeechObject(options.output),
-    shouldEndSession: options.shouldEndSession,
-  };
-
-  if (options.reprompt) {
-    alexaResponse.reprompt = {
-      outputSpeech: createSpeechObject(options.reprompt),
-    };
-  }
-
-  if (options.cardTitle && options.cardContent) {
-    alexaResponse.card = {
-      type: 'Simple',
-      title: options.cardTitle,
-      content: options.cardContent,
-    };
-
-    if (options.cardImage && (options.cardImage.smallImageUrl || options.cardImage.largeImageUrl)) {
-      alexaResponse.card.type = 'Standard';
-      alexaResponse.card.image = {};
-
-      delete alexaResponse.card.content;
-      alexaResponse.card.text = options.cardContent;
-
-      if (options.cardImage.smallImageUrl) {
-        alexaResponse.card.image.smallImageUrl = options.cardImage.smallImageUrl;
-      }
-
-      if (options.cardImage.largeImageUrl) {
-        alexaResponse.card.image.largeImageUrl = options.cardImage.largeImageUrl;
-      }
-    }
-  } else if (options.cardType === 'LinkAccount') {
-    alexaResponse.card = {
-      type: 'LinkAccount',
-    };
-  }
-
-  const returnResult = {
-    version: '1.0',
-    response: alexaResponse,
-  };
-
-  if (options.sessionAttributes) {
-    returnResult.sessionAttributes = options.sessionAttributes;
-  }
-  return returnResult;
-}
-
-module.exports = (function exported() {
+module.exports = (function() {
   return {
     /**
      * tell - Emit speechOutput to Alexa. End session.
@@ -322,3 +227,98 @@ module.exports = (function exported() {
     },
   };
 }());
+
+/**
+ * createSpeechObject - Form SSML object from parameter object.
+ *
+ * @param  {Object} optionsParam  Object with 'type' and 'speech' properties.
+ * @return {Object}               SSML object containg message.
+ */
+function createSpeechObject(optionsParam) {
+  if (optionsParam && optionsParam.type === 'SSML') {
+    return {
+      type: optionsParam.type,
+      ssml: optionsParam.speech,
+    };
+  }
+  return {
+    type: optionsParam.type || 'PlainText',
+    text: optionsParam.speech || optionsParam,
+  };
+}
+
+/**
+ * buildSpeechletResponse - Generate full speechlet response using options object.
+ *
+ * @param  {Object} options Object with properties to use in response.
+ * @return {Object}         Response object with all parameters
+ */
+function buildSpeechletResponse(options) {
+  const alexaResponse = {
+    outputSpeech: createSpeechObject(options.output),
+    shouldEndSession: options.shouldEndSession,
+  };
+
+  if (options.reprompt) {
+    alexaResponse.reprompt = {
+      outputSpeech: createSpeechObject(options.reprompt),
+    };
+  }
+
+  if (options.cardTitle && options.cardContent) {
+    alexaResponse.card = {
+      type: 'Simple',
+      title: options.cardTitle,
+      content: options.cardContent,
+    };
+
+    if (options.cardImage && (options.cardImage.smallImageUrl || options.cardImage.largeImageUrl)) {
+      alexaResponse.card.type = 'Standard';
+      alexaResponse.card.image = {};
+
+      delete alexaResponse.card.content;
+      alexaResponse.card.text = options.cardContent;
+
+      if (options.cardImage.smallImageUrl) {
+        alexaResponse.card.image.smallImageUrl = options.cardImage.smallImageUrl;
+      }
+
+      if (options.cardImage.largeImageUrl) {
+        alexaResponse.card.image.largeImageUrl = options.cardImage.largeImageUrl;
+      }
+    }
+  } else if (options.cardType === 'LinkAccount') {
+    alexaResponse.card = {
+      type: 'LinkAccount',
+    };
+  }
+
+  const returnResult = {
+    version: '1.0',
+    response: alexaResponse,
+  };
+
+  if (options.sessionAttributes) {
+    returnResult.sessionAttributes = options.sessionAttributes;
+  }
+  return returnResult;
+}
+
+/**
+ * getSSMLResponse - Form SSML Object from string.
+ * String is wrapped in <speak> tags.
+ *
+ * NB: Cannot detect SSML-specific characters, so they must be escaped with backslash.
+ *
+ * @param  {string} message String to wrap
+ * @return {Object}         SSML object containing wrapped string
+ */
+function getSSMLResponse(message) {
+  if (message == null) {
+    return null;
+  }
+  return {
+    type: 'SSML',
+    speech: `<speak> ${message} </speak>`,
+  };
+}

--- a/lib/response.js
+++ b/lib/response.js
@@ -2,7 +2,15 @@
 
 const attributesHelper = require('./DynamoAttributesHelper');
 
-// TODO: check for ssml content in card
+/**
+ * getSSMLResponse - Form SSML Object from string.
+ * String is wrapped in <speak> tags.
+ *
+ * NB: Cannot detect SSML-specific characters, so they must be escaped with backslash.
+ *
+ * @param  {string} message String to wrap
+ * @return {Object}         SSML object containing wrapped string
+ */
 function getSSMLResponse(message) {
   if (message == null) {
     return null;
@@ -13,6 +21,12 @@ function getSSMLResponse(message) {
   };
 }
 
+/**
+ * createSpeechObject - Form SSML object from parameter object.
+ *
+ * @param  {Object} optionsParam  Object with 'type' and 'speech' properties.
+ * @return {Object}               SSML object containg message.
+ */
 function createSpeechObject(optionsParam) {
   if (optionsParam && optionsParam.type === 'SSML') {
     return {
@@ -26,6 +40,12 @@ function createSpeechObject(optionsParam) {
   };
 }
 
+/**
+ * buildSpeechletResponse - Generate full speechlet response using options object.
+ *
+ * @param  {type} options Object with properties to use in response.
+ * @return {type}         Response object with all parameters
+ */
 function buildSpeechletResponse(options) {
   const alexaResponse = {
     outputSpeech: createSpeechObject(options.output),
@@ -79,6 +99,13 @@ function buildSpeechletResponse(options) {
 
 module.exports = (function exported() {
   return {
+    /**
+     * tell - Emit speechOutput to Alexa. End session.
+     *        Can be overridden.
+     *
+     * @param  {string} speechOutput    Speech Output to emit
+     * @return {undefined}              description
+     */
     ':tell': function tell(speechOutput) {
       if (this.isOverridden()) {
         return;
@@ -91,6 +118,15 @@ module.exports = (function exported() {
       });
       this.emit(':responseReady');
     },
+
+    /**
+     * ask - Emit speech output and reprompt speech to Alexa. Don't end session.
+     *       Can be overridden.
+     *
+     * @param  {string} speechOutput    Speech Output to emit
+     * @param  {string} repromptSpeech  Reprompt Speech to emit
+     * @return {undefined}
+     */
     ':ask': function ask(speechOutput, repromptSpeech) {
       if (this.isOverridden()) {
         return;
@@ -103,6 +139,18 @@ module.exports = (function exported() {
       });
       this.emit(':responseReady');
     },
+
+    /**
+     * askWithCard - Emit speech output, reprompt speech, and card to Alexa. Don't end session.
+     *               Can be overridden.
+     *
+     * @param  {string} speechOutput    Speech Output to emit
+     * @param  {string} repromptSpeech  Reprompt Speech to emit
+     * @param  {string} cardTitle       Title of card to emit
+     * @param  {string} cardContent     Content of card to emit
+     * @param  {obj}    imageObj        Image object with 'smallImageUrl' and 'largeImageUrl' properties
+     * @return {undefined}
+     */
     ':askWithCard': function askWithCard(speechOutput, repromptSpeech, cardTitle, cardContent, imageObj) {
       if (this.isOverridden()) {
         return;
@@ -119,6 +167,17 @@ module.exports = (function exported() {
       });
       this.emit(':responseReady');
     },
+
+    /**
+     * tellWithCard - Emit speech output, and card to Alexa. End session.
+     *                Can be overridden.
+     *
+     * @param  {string} speechOutput    Speech Output to emit
+     * @param  {string} cardTitle       Title of card to emit
+     * @param  {string} cardContent     Content of card to emit
+     * @param  {obj}    imageObj        Image object with 'smallImageUrl' and 'largeImageUrl' properties
+     * @return {undefined}
+     */
     ':tellWithCard': function tellWithCard(speechOutput, cardTitle, cardContent, imageObj) {
       if (this.isOverridden()) {
         return;
@@ -134,6 +193,14 @@ module.exports = (function exported() {
       });
       this.emit(':responseReady');
     },
+
+
+    /**
+     * tellWithLinkAccountCard - Emit speech output, and 'Link Account' card to Alexa. End session.
+     *
+     * @param  {string} speechOutput Speech Output to emit
+     * @return {undefined}
+     */
     ':tellWithLinkAccountCard': function tellWithLinkAccountCard(speechOutput) {
       if (this.isOverridden()) {
         return;
@@ -147,6 +214,14 @@ module.exports = (function exported() {
       });
       this.emit(':responseReady');
     },
+
+    /**
+     * askWithLinkAccountCard - Emit speech output, reprompt speech, and 'Link Account' card to Alexa. Don't end session.
+     *
+     * @param  {string} speechOutput    Speech Output to emit
+     * @param  {string} repromptSpeech  Reprompt Speech to emit
+     * @return {undefined}
+     */
     ':askWithLinkAccountCard': function askWithLinkAccountCard(speechOutput, repromptSpeech) {
       if (this.isOverridden()) {
         return;
@@ -161,6 +236,15 @@ module.exports = (function exported() {
       });
       this.emit(':responseReady');
     },
+
+
+    /**
+     * responseReady - Emit this.handler.response to Alexa.
+     *
+     * TODO: Edit to use callback, rather than context.succeed.
+     *
+     * @return {undefined}
+     */
     ':responseReady': function responseReady() {
       if (this.isOverridden()) {
         return;
@@ -177,6 +261,14 @@ module.exports = (function exported() {
 
       this.context.succeed(this.handler.response);
     },
+
+
+    /**
+     * saveState - Save session if saveBeforeResponse is set to true, or session is about to end.
+     *
+     * @param  {boolean} forceSave Force a save, even if usual conditions aren't met.
+     * @return {undefined}
+     */
     ':saveState': function saveState(forceSave) {
       let userId = '';
       if (this.isOverridden()) {
@@ -213,6 +305,14 @@ module.exports = (function exported() {
         this.context.succeed(this.handler.response || true);
       }
     },
+
+
+    /**
+     * saveStateError - Logs error and fails, not sending response.
+     *
+     * @param  {type} err   Error to log
+     * @return {undefined}
+     */
     ':saveStateError': function saveStateError(err) {
       if (this.isOverridden()) {
         return;


### PR DESCRIPTION
This is a pretty large PR, which I suspect will take a long time to review, but I think it made sense for me to make these changes at the same time, and not in separate pulls. If you're interested in pulling this, I'm happy to make as many edits to it as necessary, as I acknowledge this is making small changes to pretty much the entire SDK... I thought I'd get the pull up now, so people can review and give me comments if they find time.

- It now makes use of several of the new ES6 features. This includes moving away from the deprecated `util.inherits` to `class`, and replacing all `var`s with `const`s or `let`s, and a few other things. 

- It now has complete JSDocs to every function and method. Let me know if and where you'd like me to add more of these.

- It is now (almost) fully compatible with the Google style guide. Here are the ESLint names of the rules it still breaks:

    1. max-len: it still has some lines longer than 80 characters.
    2. no-console: it still outputs things to the console.

Other than that, it fully obeys the syntax elements of the Google guide. I haven't removed the bugs/made the changes from my other PRs, this is simply a (large) style update.