### PR TITLE
Update Readme.md to use alexa.appId

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -294,7 +294,7 @@ To enable string internationalization features in Alexa-sdk, set resources to th
 ```javascript
 exports.handler = function(event, context, callback) {
     var alexa = Alexa.handler(event, context);
-    alexa.APP_ID = APP_ID;
+    alexa.appId = appId;
     // To enable string internationalization (i18n) features, set a resources object.
     alexa.resources = languageStrings;
     alexa.registerHandlers(handlers);


### PR DESCRIPTION
References #103.

I had been using `alexa.APP_ID` as shown in the documentation and kept getting warnings that the application id hadn't been set. Looks like `appId` used to be `APP_ID` but wasn't updated here.