### PR TITLE
Remove context.succeed/callback calls from savestate

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -236,29 +236,11 @@ module.exports = (function () {
             }
 
             if(this.handler.saveBeforeResponse || forceSave || this.handler.response.response.shouldEndSession) {
-                attributesHelper.set(this.handler.dynamoDBTableName, userId, this.attributes,
-                    (err) => {
-                        if(err) {
-                            return this.emit(':saveStateError', err);
-                        }
-
-                        // To save the state when AudioPlayer Requests come without sending a response.
-                        if (Object.keys(this.handler.response).length === 0 && this.handler.response.constructor === Object) {
-                            this.handler.response =  true;
-                        }
-
-                        if(typeof this._callback === 'undefined') {
-                            this.context.succeed(this.handler.response)
-                        } else {
-                            this._callback(null, this.handler.response);
-                        }
-                    });
-            } else {
-                if(typeof this._callback === 'undefined') {
-                    this.context.succeed(this.handler.response || true)
-                } else {
-                    this._callback(null, this.handler.response || true);
-                }
+                attributesHelper.set(this.handler.dynamoDBTableName, userId, this.attributes, (err) => {
+                    if(err) {
+                        return this.emit(':saveStateError', err);
+                    }
+                });
             }
         },
         ':saveStateError': function(err) {
@@ -267,10 +249,10 @@ module.exports = (function () {
             }
             console.log(`Error saving state: ${err}\n${err.stack}`);
             if(typeof this._callback === 'undefined') {
-                this.context.fail(err)
+                this.context.fail(err);
             } else {
                 this._callback(err);
-            }            
+            }
         }
     };
 })();

--- a/lib/response.js
+++ b/lib/response.js
@@ -208,7 +208,7 @@ module.exports = (function () {
             }
 
             if (this.handler.dynamoDBTableName) {
-                return this.emit(':saveState');
+                this.emit(':saveState');
             }
 
             if(typeof this.callback === 'undefined') {


### PR DESCRIPTION
This makes `this.emit(':saveState')` perform as expected, without calling anything that ends the session unless there's an error. This should resolve https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/issues/88. Note that no changes to documentation really need to be made, as actually it now performs as it's documented, without sending off a response. Let me know if you need any further changes - I'm fairly confident it now has the expected behaviour, but not totally sure. 🙂 