### PR TITLE
Expose the ability to inject a custom DynamoDB client

### DIFF
--- a/lib/DynamoAttributesHelper.js
+++ b/lib/DynamoAttributesHelper.js
@@ -24,7 +24,6 @@ module.exports = function(options) {
                     console.log('get error: ' + JSON.stringify(err, null, 4));
 
                     if(err.code === 'ResourceNotFoundException') {
-                        console.log("Trying to create new table");
                         newTableParams['TableName'] = table;
                         dynamoDBClient.createTable(newTableParams, function (err, data) {
                             if(err) {

--- a/lib/DynamoAttributesHelper.js
+++ b/lib/DynamoAttributesHelper.js
@@ -1,16 +1,14 @@
 'use strict';
 var aws = require('aws-sdk');
-var doc;
 
-module.exports = (function() {
+module.exports = function(options) {
+    var dynamoDBClient = options.dynamoDBClient || new aws.DynamoDB({apiVersion: '2012-08-10'});
+    var doc = new aws.DynamoDB.DocumentClient({service: dynamoDBClient});
+
     return {
         get: function(table, userId, callback) {
             if(!table) {
                 callback('DynamoDB Table name is not set.', null);
-            }
-
-            if(!doc) {
-                doc = new aws.DynamoDB.DocumentClient({apiVersion: '2012-08-10'});
             }
 
             var params = {
@@ -26,9 +24,9 @@ module.exports = (function() {
                     console.log('get error: ' + JSON.stringify(err, null, 4));
 
                     if(err.code === 'ResourceNotFoundException') {
-                        var dynamoClient = new aws.DynamoDB();
+                        console.log("Trying to create new table");
                         newTableParams['TableName'] = table;
-                        dynamoClient.createTable(newTableParams, function (err, data) {
+                        dynamoDBClient.createTable(newTableParams, function (err, data) {
                             if(err) {
                                 console.log('Error creating table: ' + JSON.stringify(err, null, 4));
                             }
@@ -53,10 +51,6 @@ module.exports = (function() {
                 callback('DynamoDB Table name is not set.', null);
             }
 
-            if(!doc) {
-                doc = new aws.DynamoDB.DocumentClient({apiVersion: '2012-08-10'});
-            }
-
             var params = {
                 Item: {
                     userId: userId,
@@ -73,7 +67,7 @@ module.exports = (function() {
             });
         }
     };
-})();
+};
 
 function isEmptyObject(obj) {
     return !Object.keys(obj).length;

--- a/lib/alexa.js
+++ b/lib/alexa.js
@@ -154,13 +154,13 @@ function ValidateRequest() {
         }
 
         if(this.dynamoDBTableName && (!event.session.sessionId || event.session['new']) ) {
-            attributesHelper.get(this.dynamoDBTableName, userId, (err, data) => {
+            attributesHelper({dynamoDBClient: this.dynamoDBClient}).get(this.dynamoDBTableName, userId, (err, data) => {
                 if(err) {
                     var error = new Error('Error fetching user state: ' + err)
                     if(typeof callback === 'undefined') {
                         return context.fail(error)
                     } else {
-                        return  callback(error);
+                        return callback(error);
                     }
                 }
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -236,7 +236,7 @@ module.exports = (function () {
             }
 
             if(this.handler.saveBeforeResponse || forceSave || this.handler.response.response.shouldEndSession) {
-                attributesHelper.set(this.handler.dynamoDBTableName, userId, this.attributes, (err) => {
+                attributesHelper({dynamoDBClient: this.handler.dynamoDBClient}).set(this.handler.dynamoDBTableName, userId, this.attributes, (err) => {
                     if(err) {
                         return this.emit(':saveStateError', err);
                     }


### PR DESCRIPTION
- Imagined use case: TDD using dynamoDB local
- Set your own client using `<Alexa Handler>.dynamoDBClient`
- If not set, it uses the default client to keep things convention over configuration