### PR TITLE
Add userId to handler's property

### DIFF
--- a/lib/alexa.js
+++ b/lib/alexa.js
@@ -21,6 +21,13 @@ function alexaRequestHandler(event, context, callback) {
         event.session['attributes'] = {};
     }
 
+    var userId = '';
+    if (event.context) {
+        userId = event.context.System.user.userId;
+    } else if (event.session) {
+        userId = event.session.user.userId;
+    }
+
     var handler = new AlexaRequestEmitter();
     handler.setMaxListeners(Infinity);
 
@@ -43,6 +50,11 @@ function alexaRequestHandler(event, context, callback) {
         value: null,
         writable: true,
         configurable: true
+    });
+
+    Object.defineProperty(handler, 'userId', {
+        value: userId,
+        writable: false
     });
 
     Object.defineProperty(handler, 'appId', {


### PR DESCRIPTION
## Overview

When I access to `userId` in intent functions. I need to write code as below.

```
"NewSession": function() {
  var userId = ''
  if(event.context) {
    userId = event.context.System.user.userId;
  } else if (event.session) {
    userId = event.session.user.userId;
  }
  ...
}
```

I think it is more complicated than necessary. So define `userId` property to access simply.