### PR TITLE
Adding ability to plugin in custom attributesHelper

### DIFF
--- a/lib/alexa.js
+++ b/lib/alexa.js
@@ -81,6 +81,11 @@ function alexaRequestHandler(event, context, callback) {
         writable: true
     });
 
+    Object.defineProperty(handler, 'attributesHelper', {
+        value: attributesHelper,
+        writable: true
+    });
+
     Object.defineProperty(handler, 'registerHandlers', {
         value: function() {
             RegisterHandlers.apply(handler, arguments);
@@ -155,7 +160,7 @@ function ValidateRequest() {
         }
 
         if(this.dynamoDBTableName && (!event.session.sessionId || event.session['new']) ) {
-            attributesHelper.get(this.dynamoDBTableName, userId, (err, data) => {
+            this.attributesHelper.get(this.dynamoDBTableName, userId, (err, data) => {
                 if(err) {
                     var error = new Error('Error fetching user state: ' + err);
                     if(typeof callback === 'undefined') {

--- a/lib/response.js
+++ b/lib/response.js
@@ -236,7 +236,7 @@ module.exports = (function () {
             }
 
             if(this.handler.saveBeforeResponse || forceSave || this.handler.response.response.shouldEndSession) {
-                attributesHelper.set(this.handler.dynamoDBTableName, userId, this.attributes, (err) => {
+                this.handler.attributesHelper.set(this.handler.dynamoDBTableName, userId, this.attributes, (err) => {
                     if(err) {
                         return this.emit(':saveStateError', err);
                     }


### PR DESCRIPTION
While working with the SDK to deploy my alexa service on non-AWS environment, I had a need to persist the session storage on a different store apart from the default DynamoDB based setup. I looked at the `DynamoAttributesHelper.js` and it was nice enough to be abstracted for any other custom stores. So in [one of my hacks](https://github.com/ashwanthkumar/devmerge-2017/blob/master/alexa/mongo_alexa_sdk_helper.js) I built one for Mongo based attributesHelper for this SDK.

I can see that the changes as part of this PR is not in a very pretty shape yet. I wanted to take help from you all to better it, but before that I wanted to discuss is this something you would consider supporting? 