### PR TITLE
Fix typo in ImageUtils.makeImages documentation

### DIFF
--- a/lib/utils/imageUtils.js
+++ b/lib/utils/imageUtils.js
@@ -64,7 +64,7 @@ class ImageUtils {
      *  { 'https://url/to/my/small.png', 300, 400, 'SMALL' },
      *  { 'https://url/to/my/large.png', 900, 1200, 'LARGE' },
      * ]
-     *  ImageUtils.makeImage(imgArr, 'image description')
+     * ImageUtils.makeImages(imgArr, 'image description')
      *
      * @static
      * @param {{url : string, widthPixels : number, heightPixels : number, size : string}[]} imgArr 


### PR DESCRIPTION
Original documentation inside `imageUtils.js` referred to `ImageUtils.makeImage` for the `ImageUtils.makeImages` method. This PR fixes it to plural.