### PR TITLE
Adding test coverage to the project and getting 100% statement coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 node_modules
+reports
+coverage
+*.DS_Store
+.nyc_output

--- a/gulpfile.base.js
+++ b/gulpfile.base.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const gulp = require('gulp');
-const mocha = require('gulp-mocha');
 const jshint = require('gulp-jshint');
 
 module.exports = {

--- a/gulpfile.base.js
+++ b/gulpfile.base.js
@@ -9,9 +9,5 @@ module.exports = {
         return gulp.src(['lib/**/*.js', 'test/**/*.js'])
                .pipe(jshint())
                .pipe(jshint.reporter('default'));
-    },
-    test : () => {
-        return gulp.src('test/**/*.spec.js', { read : false })
-            .pipe(mocha({ reporter : 'nyan' }));
     }
 };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,6 @@
 const gulp = require('gulp');
 const gulp_base = require('./gulpfile.base');
 
-gulp.task('test', gulp_base.test);
 gulp.task('lint', gulp_base.lint);
 
-gulp.task('default', ['test', 'lint']);
+gulp.task('default', ['lint']);

--- a/lib/responseBuilder.js
+++ b/lib/responseBuilder.js
@@ -287,7 +287,7 @@ class ResponseBuilder {
             }
         };
 
-        if (playVideoDirective.videoItem.metadata) {
+        if (metadata) {
             playVideoDirective.videoItem.metadata = metadata;
         }
 

--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
     "chai": "^4.1.0",
     "gulp": "^3.9.1",
     "gulp-jshint": "^2.0.4",
-    "gulp-mocha": "^4.3.1",
     "jshint": "^2.9.5",
-    "mocha": "^3.5.0"
+    "mocha": "^3.5.3",
+    "nyc": "^11.2.1"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "nyc --reporter=html --reporter=text mocha --timeout=3000 --reporter nyan test/*.spec.js test/**/*.spec.js"
   },
   "repository": {
     "type": "git",

--- a/test/responseBuilder.spec.js
+++ b/test/responseBuilder.spec.js
@@ -40,12 +40,12 @@ describe('ResponseBuilder Tests', () => {
         expect(result).to.equal(responseBuilder);
     });
 
-      it('should make a card', () => {
+    it('should make a card', () => {
         const expectedTitle = 'my reprompt';
-        const result = responseBuilder.cardRenderer(expectedTitle, "", {});
+        const result = responseBuilder.cardRenderer(expectedTitle, "card content", { smallImageUrl : 'small_url', largeImageUrl : 'larg_url' });
 
         expect(response.card.title).to.contain(expectedTitle);
-        expect(result).to.equal(responseBuilder);
+        expect(result).to.deep.equal(responseBuilder);
     });
 
     it('should make a link account card', () => {
@@ -53,6 +53,20 @@ describe('ResponseBuilder Tests', () => {
 
         expect(response.card.type).to.equal(CARD_TYPES.LINK_ACCOUNT);
         expect(result).to.equal(responseBuilder);
+    });
+
+    it('should create audioPlayer directive', () => {
+        const playDirective = responseBuilder.audioPlayer('play', 'behavior', 'url', 'token', '', 100);
+        const stopDirective = responseBuilder.audioPlayer('stop', 'behavior', 'url', 'token', '', 100);
+        const clearQueueDirective = responseBuilder.audioPlayer('', 'behavior', 'url', 'token', '', 100);
+        
+        expect(response.directives.length).to.equal(3);
+        expect(response.directives[0].type).to.equal(DIRECTIVE_TYPES.AUDIOPLAYER.PLAY);
+        expect(response.directives[1].type).to.equal(DIRECTIVE_TYPES.AUDIOPLAYER.STOP);
+        expect(response.directives[2].type).to.equal(DIRECTIVE_TYPES.AUDIOPLAYER.CLEAR_QUEUE);
+        expect(playDirective).to.deep.equal(responseBuilder);
+        expect(stopDirective).to.deep.equal(responseBuilder);
+        expect(clearQueueDirective).to.deep.equal(responseBuilder);
     });
 
     it('should create audioPlayer directive on play', () => {
@@ -102,10 +116,11 @@ describe('ResponseBuilder Tests', () => {
     });
 
     it('should create videoapp directive', () => {
-        const result = responseBuilder.playVideo('url');
+        const result = responseBuilder.playVideo('url', { metadata: 'text' });
         expect(response.directives.length).to.equal(1);
         expect(response.directives[0].type).to.equal(DIRECTIVE_TYPES.VIDEOAPP.LAUNCH);
-        expect(result).to.equal(responseBuilder);
+        expect(result).to.deep.equal(responseBuilder);
+        expect(result._responseObject.response.directives).to.have.deep.members(responseBuilder._responseObject.response.directives);
     });
 
     it('should remove shouldEndSession when specifying videoApp directive', () => {

--- a/test/templateBuilders/bodyTemplate1Builder.spec.js
+++ b/test/templateBuilders/bodyTemplate1Builder.spec.js
@@ -9,23 +9,27 @@ const TextUtils = require('../../lib/utils/textUtils').TextUtils;
 describe('BodyTemplate1Builder', () => {
     it('should create BodyTemplate1', () => {
         const expectedBackButtonBehavior = 'VISIBLE';
-        const expectedBgImage = ImageUtils.makeImage('url');
+        const expectedBgImage = ImageUtils.makeImage('url', 800, 600, 'X_SMALL', 'image desc');
         const expectedPrimaryText = TextUtils.makePlainText('text');
+        const expectedSecondaryText = TextUtils.makePlainText('secondary text');
+        const expectedTertiaryText = TextUtils.makeRichText('tertiary text');
         const expectedTitle = 'title';
         const expectedToken = 'token';
 
         const template = new BodyTemplate1Builder()
                                     .setBackButtonBehavior(expectedBackButtonBehavior)
                                     .setBackgroundImage(expectedBgImage)
-                                    .setTextContent(expectedPrimaryText)
+                                    .setTextContent(expectedPrimaryText, expectedSecondaryText, expectedTertiaryText)
                                     .setTitle(expectedTitle)
                                     .setToken(expectedToken)
                                     .build();
-        
+
         expect(template.type).to.equal('BodyTemplate1');
         expect(template.backButton).to.equal(expectedBackButtonBehavior);
-        expect(template.backgroundImage).to.equal(expectedBgImage);
-        expect(template.textContent.primaryText).to.equal(expectedPrimaryText);
+        expect(template.backgroundImage).to.deep.equal(expectedBgImage);
+        expect(template.textContent.primaryText).to.deep.equal(expectedPrimaryText);
+        expect(template.textContent.secondaryText).to.deep.equal(expectedSecondaryText);
+        expect(template.textContent.tertiaryText).to.deep.equal(expectedTertiaryText);
         expect(template.token).to.equal(expectedToken);
         expect(template.title).to.equal(expectedTitle);
     });

--- a/test/templateBuilders/bodyTemplate2Builder.spec.js
+++ b/test/templateBuilders/bodyTemplate2Builder.spec.js
@@ -9,8 +9,10 @@ const TextUtils = require('../../lib/utils/textUtils').TextUtils;
 describe('BodyTemplate2Builder', () => {
     it('should create BodyTemplate2', () => {
         const expectedBackButtonBehavior = 'HIDDEN';
-        const expectedBgImage = ImageUtils.makeImage('url');
+        const expectedBgImage = ImageUtils.makeImage('url', 800, 600, 'SMALL', 'image desc');
         const expectedPrimaryText = TextUtils.makePlainText('text');
+        const expectedSecondaryText = TextUtils.makePlainText('secondary text');
+        const expectedTertiaryText = TextUtils.makeRichText('tertiary text');
         const expectedTitle = 'title';
         const expectedToken = 'token';
         const expectedFgImage = ImageUtils.makeImage('url2');
@@ -18,7 +20,7 @@ describe('BodyTemplate2Builder', () => {
         const template = new BodyTemplate2Builder()
                                     .setBackButtonBehavior(expectedBackButtonBehavior)
                                     .setBackgroundImage(expectedBgImage)
-                                    .setTextContent(expectedPrimaryText)
+                                    .setTextContent(expectedPrimaryText, expectedSecondaryText, expectedTertiaryText)
                                     .setTitle(expectedTitle)
                                     .setToken(expectedToken)
                                     .setImage(expectedFgImage)
@@ -26,10 +28,10 @@ describe('BodyTemplate2Builder', () => {
         
         expect(template.type).to.equal('BodyTemplate2');
         expect(template.backButton).to.equal(expectedBackButtonBehavior);
-        expect(template.backgroundImage).to.equal(expectedBgImage);
-        expect(template.textContent.primaryText).to.equal(expectedPrimaryText);
+        expect(template.backgroundImage).to.deep.equal(expectedBgImage);
+        expect(template.textContent.primaryText).to.deep.equal(expectedPrimaryText);
         expect(template.token).to.equal(expectedToken);
         expect(template.title).to.equal(expectedTitle);
-        expect(template.image).to.equal(expectedFgImage);
+        expect(template.image).to.deep.equal(expectedFgImage);
     });
 });

--- a/test/templateBuilders/bodyTemplate3Builder.spec.js
+++ b/test/templateBuilders/bodyTemplate3Builder.spec.js
@@ -9,8 +9,10 @@ const TextUtils = require('../../lib/utils/textUtils').TextUtils;
 describe('BodyTemplate3Builder', () => {
     it('should create BodyTemplate3', () => {
         const expectedBackButtonBehavior = 'HIDDEN';
-        const expectedBgImage = ImageUtils.makeImage('url');
+        const expectedBgImage = ImageUtils.makeImage('url', 800, 600, 'MEDIUM', 'image desc');
         const expectedPrimaryText = TextUtils.makePlainText('text');
+        const expectedSecondaryText = TextUtils.makePlainText('secondary text');
+        const expectedTertiaryText = TextUtils.makeRichText('tertiary text');
         const expectedTitle = 'title';
         const expectedToken = 'token';
         const expectedFgImage = ImageUtils.makeImage('url2');
@@ -18,7 +20,7 @@ describe('BodyTemplate3Builder', () => {
         const template = new BodyTemplate3Builder()
                                     .setBackButtonBehavior(expectedBackButtonBehavior)
                                     .setBackgroundImage(expectedBgImage)
-                                    .setTextContent(expectedPrimaryText)
+                                    .setTextContent(expectedPrimaryText, expectedSecondaryText, expectedTertiaryText)
                                     .setTitle(expectedTitle)
                                     .setToken(expectedToken)
                                     .setImage(expectedFgImage)
@@ -26,10 +28,10 @@ describe('BodyTemplate3Builder', () => {
         
         expect(template.type).to.equal('BodyTemplate3');
         expect(template.backButton).to.equal(expectedBackButtonBehavior);
-        expect(template.backgroundImage).to.equal(expectedBgImage);
-        expect(template.textContent.primaryText).to.equal(expectedPrimaryText);
+        expect(template.backgroundImage).to.deep.equal(expectedBgImage);
+        expect(template.textContent.primaryText).to.deep.equal(expectedPrimaryText);
         expect(template.token).to.equal(expectedToken);
         expect(template.title).to.equal(expectedTitle);
-        expect(template.image).to.equal(expectedFgImage);
+        expect(template.image).to.deep.equal(expectedFgImage);
     });
 });

--- a/test/templateBuilders/bodyTemplate6Builder.spec.js
+++ b/test/templateBuilders/bodyTemplate6Builder.spec.js
@@ -9,8 +9,10 @@ const TextUtils = require('../../lib/utils/textUtils').TextUtils;
 describe('BodyTemplate6Builder', () => {
     it('should create BodyTemplate6', () => {
         const expectedBackButtonBehavior = 'HIDDEN';
-        const expectedBgImage = ImageUtils.makeImage('url');
+        const expectedBgImage = ImageUtils.makeImage('url', 800, 600, 'LARGE', 'image desc');
         const expectedPrimaryText = TextUtils.makePlainText('text');
+        const expectedSecondaryText = TextUtils.makePlainText('secondary text');
+        const expectedTertiaryText = TextUtils.makeRichText('tertiary text');
         const expectedTitle = 'title';
         const expectedToken = 'token';
         const expectedFgImage = ImageUtils.makeImage('url2');
@@ -18,7 +20,7 @@ describe('BodyTemplate6Builder', () => {
         const template = new BodyTemplate6Builder()
                                     .setBackButtonBehavior(expectedBackButtonBehavior)
                                     .setBackgroundImage(expectedBgImage)
-                                    .setTextContent(expectedPrimaryText)
+                                    .setTextContent(expectedPrimaryText, expectedSecondaryText, expectedTertiaryText)
                                     .setTitle(expectedTitle)
                                     .setToken(expectedToken)
                                     .setImage(expectedFgImage)
@@ -26,10 +28,10 @@ describe('BodyTemplate6Builder', () => {
         
         expect(template.type).to.equal('BodyTemplate6');
         expect(template.backButton).to.equal(expectedBackButtonBehavior);
-        expect(template.backgroundImage).to.equal(expectedBgImage);
-        expect(template.textContent.primaryText).to.equal(expectedPrimaryText);
+        expect(template.backgroundImage).to.deep.equal(expectedBgImage);
+        expect(template.textContent.primaryText).to.deep.equal(expectedPrimaryText);
         expect(template.token).to.equal(expectedToken);
         expect(template.title).to.equal(expectedTitle);
-        expect(template.image).to.equal(expectedFgImage);
+        expect(template.image).to.deep.equal(expectedFgImage);
     });
 });


### PR DESCRIPTION
in this PR I'm using [Istanbul](https://istanbul.js.org/) to measure the code coverage in this project.
I also improved the tests to make 100% statement coverage:
![image](https://user-images.githubusercontent.com/1692542/30687354-d82cd4d4-9e6f-11e7-92d4-47fd66c4adf8.png)

In order to run the test run the command `npm run test`.
![image](https://user-images.githubusercontent.com/1692542/30687614-b4b7ce72-9e70-11e7-9709-ad339f7095bf.png)

I decided not to use [gulp-mocha](https://github.com/sindresorhus/gulp-mocha) anymore since the latest version doesn't support code coverage (open [issue](https://github.com/sindresorhus/gulp-mocha/issues/159)), I tested it using gulp-coverage and it showed the same bug.

