### PR TITLE
Randomly select a translation from multiple options where available

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -362,7 +362,12 @@ var languageStrings = {
     },
     'en-US': {
         'translation': {
-            'SAY_HELLO_MESSAGE' : 'Hello World!'
+            // When there are multiple values a random one will be selected.
+            'SAY_HELLO_MESSAGE' : [
+              'Hello World!',
+              'Hi there World!',
+              'Howa doing World?'
+            ]
         }
     },
     'de-DE': {
@@ -380,6 +385,9 @@ exports.handler = function(event, context, callback) {
     alexa.appId = appId;
     // To enable string internationalization (i18n) features, set a resources object.
     alexa.resources = languageStrings;
+    // Set to firstTranslationOnly to disable random phrase selection and return stable
+    // values, most useful when writing automated tests.
+    alexa.firstTranslationOnly = false;
     alexa.registerHandlers(handlers);
     alexa.execute();
 };

--- a/lib/alexa.js
+++ b/lib/alexa.js
@@ -78,6 +78,11 @@ function alexaRequestHandler(event, context, callback) {
         writable: true
     });
 
+    Object.defineProperty(handler, 'firstTranslationOnly', {
+        value: false,
+        writable: true
+    });
+
     Object.defineProperty(handler, 'resources', {
         value: undefined,
         writable: true
@@ -108,7 +113,23 @@ function HandleLambdaEvent() {
     if(this.resources) {
         this.i18n.use(sprintf).init({
             overloadTranslationOptionHandler: sprintf.overloadTranslationOptionHandler,
-            returnObjects: true,
+            returnObjects: false,
+            returnedObjectHandler: (key, value, options) => {
+                // When the value returned is an array select a random translation
+                // from that array and return it.
+                if (Object.prototype.toString.apply(value) === '[object Array]') {
+                    if (this.firstTranslationOnly) {
+                        return value[0];
+                    } else {
+                        let count = value.length;
+                        let idx = Math.floor(Math.random() * count);
+
+                        return value[idx];
+                    }
+                } else {
+                  return value;
+                }
+            },
             lng: this.locale,
             resources: this.resources
         }, (err) => {


### PR DESCRIPTION
This feature is designed to make it easier to implement the voice UI design recommendation to add variety in Alexa's responses. In cases where it would impact existing code, or for automated tests, the feature can be disabled by setting the `firstTranslationOnly` option to `true`.