### PR TITLE
npm test command runnable

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "nock": "^9.0.25"
   },
   "scripts": {
-    "test": "./node_modules/mocha/bin/_mocha"
+    "test": "gulp test",
+    "lint": "gulp lint"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "nock": "^9.0.25"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./node_modules/mocha/bin/_mocha"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "nock": "^9.0.25"
   },
   "scripts": {
-    "test": "gulp test",
-    "lint": "gulp lint"
+    "test": "./node_modules/.bin/gulp test",
+    "lint": "./node_modules/.bin/gulp lint"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
For now, `npm test` command is in-active.
I thinks the command should run mocha's tests.

So I've update `package.json` to run `./node_modules/mocha/bin/_mocha ` as `npm test`


## Running result of `npm test`
<img width="753" alt="2017-11-29 16 01 09" src="https://user-images.githubusercontent.com/6883571/33405779-9314616a-d51e-11e7-9a10-86eab7481abb.png">
