### PR TITLE
Disabling value escaping from translations

### DIFF
--- a/lib/alexa.js
+++ b/lib/alexa.js
@@ -107,6 +107,7 @@ function HandleLambdaEvent() {
     this.locale = this._event.request.locale;
     if(this.resources) {
         this.i18n.use(sprintf).init({
+            interpolation: { escapeValue: false },
             overloadTranslationOptionHandler: sprintf.overloadTranslationOptionHandler,
             returnObjects: true,
             lng: this.locale,


### PR DESCRIPTION
Escapes encoding by default for translations according to the documentation:

https://www.i18next.com/interpolation.html#additional-options