### PR TITLE
DynamoDB Time to Live

### DIFF
--- a/lib/DynamoAttributesHelper.js
+++ b/lib/DynamoAttributesHelper.js
@@ -64,6 +64,9 @@ module.exports = (function() {
                 },
                 TableName: table
             };
+            if('TTL' in data) {
+                params.Item.TTL = data.TTL;
+            }
 
             doc.put(params, function(err, data) {
                 if(err) {

--- a/lib/DynamoAttributesHelper.js
+++ b/lib/DynamoAttributesHelper.js
@@ -64,9 +64,6 @@ module.exports = (function() {
                 },
                 TableName: table
             };
-            if('TTL' in data) {
-                params.Item.TTL = data.TTL;
-            }
 
             doc.put(params, function(err, data) {
                 if(err) {


### PR DESCRIPTION
A small change to provide access to DynamoDB's Time To Live feature for attribute storage.
Usage:
this.attributes.TTL =  \<time\>
where \<time\> is epoch time in seconds at which the item containing
the current attributes will expire, unless TTL is updated before that
time is reached. Requires enabling Time To Live on the table for it to 
have an effect.