### PR TITLE
injecting a custom DynamoDB client

### DIFF
--- a/lib/DynamoAttributesHelper.js
+++ b/lib/DynamoAttributesHelper.js
@@ -2,15 +2,14 @@
 var aws = require('aws-sdk');
 var doc;
 
-module.exports = (function() {
+module.exports = function(client) {
+    var dynamoDBClient = client || new aws.DynamoDB({apiVersion: '2012-08-10'});
+    var doc = new aws.DynamoDB.DocumentClient({service: dynamoDBClient});
+
     return {
         get: function(table, userId, callback) {
             if(!table) {
                 callback('DynamoDB Table name is not set.', null);
-            }
-
-            if(!doc) {
-                doc = new aws.DynamoDB.DocumentClient({apiVersion: '2012-08-10'});
             }
 
             var params = {
@@ -28,7 +27,7 @@ module.exports = (function() {
                     if(err.code === 'ResourceNotFoundException') {
                         var dynamoClient = new aws.DynamoDB();
                         newTableParams.TableName = table;
-                        dynamoClient.createTable(newTableParams, function (err, data) {
+                        dynamoDBClient.createTable(newTableParams, function (err, data) {
                             if(err) {
                                 console.log('Error creating table: ' + JSON.stringify(err, null, 4));
                             }
@@ -53,10 +52,6 @@ module.exports = (function() {
                 callback('DynamoDB Table name is not set.', null);
             }
 
-            if(!doc) {
-                doc = new aws.DynamoDB.DocumentClient({apiVersion: '2012-08-10'});
-            }
-
             var params = {
                 Item: {
                     userId: userId,
@@ -73,7 +68,7 @@ module.exports = (function() {
             });
         }
     };
-})();
+};
 
 function isEmptyObject(obj) {
     return !Object.keys(obj).length;

--- a/lib/alexa.js
+++ b/lib/alexa.js
@@ -63,6 +63,11 @@ function alexaRequestHandler(event, context, callback) {
         writable: true
     });
 
+    Object.defineProperty(handler, 'dynamoDBClient', {
+        value: null,
+        writable: true
+    });
+
     Object.defineProperty(handler, 'saveBeforeResponse', {
         value: false,
         writable: true
@@ -158,7 +163,7 @@ function ValidateRequest() {
         }
 
         if(this.dynamoDBTableName && (!event.session.sessionId || event.session['new']) ) {
-            attributesHelper.get(this.dynamoDBTableName, userId, (err, data) => {
+            attributesHelper(this.dynamoDBClient).get(this.dynamoDBTableName, userId, (err, data) => {
                 if(err) {
                     var error = new Error('Error fetching user state: ' + err);
                     if(typeof callback === 'undefined') {

--- a/lib/response.js
+++ b/lib/response.js
@@ -251,7 +251,7 @@ module.exports = (function () {
             }
 
             if(this.handler.saveBeforeResponse || forceSave || this.handler.response.response.shouldEndSession) {
-                attributesHelper.set(this.handler.dynamoDBTableName, userId, this.attributes,
+                attributesHelper(this.handler.dynamoDBClient).set(this.handler.dynamoDBTableName, userId, this.attributes,
                     (err) => {
                         if(err) {
                             return this.emit(':saveStateError', err);
@@ -285,7 +285,7 @@ module.exports = (function () {
                 this.context.fail(err);
             } else {
                 this.callback(err);
-            }            
+            }
         }
     };
 })();


### PR DESCRIPTION
I'm new to this so any feedback about the types/appropriate location of comments/documentation I make is appreciated.  I wanted to use a local DynamoDB client, and continued with work started by @daemonsy mentioned in #140.  This PR allows user to define `<Alexa Handler>.dynamoDBClient`, for example:

    alexa.dynamoDBClient = new aws.DynamoDB({
        accessKeyId: 'AKID',
        secretAccessKey: 'SECRET',
        region: "us-east-1",
        endpoint: "http://localhost:8000",
        apiVersion: '2012-08-10'
    });

I will make further comments in #140 .