### PR TITLE
Improve isObject check

### DIFF
--- a/lib/alexa.js
+++ b/lib/alexa.js
@@ -264,7 +264,7 @@ function RegisterHandlers() {
 }
 
 function isObject(obj) {
-    return (!!obj) && (obj.constructor === Object);
+    return !!obj && Object.prototype.toString.call(obj) === '[object Object]';
 }
 
 function IsOverridden(name) {


### PR DESCRIPTION
Source: https://toddmotto.com/understanding-javascript-types-and-reliable-type-checking/#true-object-types

This is a slightly better check for objects as it allows ES2015 Proxy
objects as well. Proxies behave like objects, but the `constructor`
property of a Proxy is Function, instead of Object.

Proxies can be useful in implementing, for example, a catch-all handler
function for an Alexa Skill.