### PR TITLE
fix trim of SSML speech. Length of start tag is 7

### DIFF
--- a/ask-sdk-core/lib/response/ResponseFactory.ts
+++ b/ask-sdk-core/lib/response/ResponseFactory.ts
@@ -64,7 +64,7 @@ export class ResponseFactory {
             const speech = speechOutput.trim();
             const length = speech.length;
             if (speech.startsWith('<speak>') && speech.endsWith('</speak>')) {
-                return speech.substring(8, length - 8).trim();
+                return speech.substring(7, length - 8).trim();
             }
 
             return speech;

--- a/ask-sdk-core/tst/response/ResponseFactory.spec.ts
+++ b/ask-sdk-core/tst/response/ResponseFactory.spec.ts
@@ -44,6 +44,7 @@ describe('ResponseFactory', () => {
         const responseBuilder : ResponseBuilder = ResponseFactory.init();
         const speechOutput = '<speak>   HelloWorld!  </speak>';
         const speechOutput2 = '  <speak>  HelloWorld! </speak>  ';
+        const speechOutput3 = '<speak>HelloWorld!</speak>';
         const expectResponse = {
             outputSpeech: {
                 ssml: '<speak>' + 'HelloWorld!' + '</speak>',
@@ -52,6 +53,7 @@ describe('ResponseFactory', () => {
         };
         expect(responseBuilder.speak(speechOutput).getResponse()).to.deep.equal(expectResponse);
         expect(responseBuilder.speak(speechOutput2).getResponse()).to.deep.equal(expectResponse);
+        expect(responseBuilder.speak(speechOutput3).getResponse()).to.deep.equal(expectResponse);
     });
 
     it('should build response with Ssml reprompt', () => {


### PR DESCRIPTION
## Description
The trimming of SSML tags is off by one.

## Motivation and Context
The trimming of SSML tags is off by one.

## Testing
I added a unit test

## Screenshots (if appropriate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
