### PR TITLE
add possibility to provide speech array and let SDK pick one

### DIFF
--- a/ask-sdk-core/lib/response/ResponseBuilder.ts
+++ b/ask-sdk-core/lib/response/ResponseBuilder.ts
@@ -25,18 +25,19 @@ import {
  */
 export interface ResponseBuilder {
     /**
-     * Has Alexa say the provided speech to the user
+     * Has Alexa say the provided speech to the user. If speechOutput is an array, pick one of the strings randomly.
      * @param {string} speechOutput
      * @returns {ResponseBuilder}
      */
-    speak(speechOutput : string) : this;
+    speak(speechOutput : string | string[]) : this;
     /**
      * Has alexa listen for speech from the user. If the user doesn't respond within 8 seconds
-     * then has alexa reprompt with the provided reprompt speech
+     * then has alexa reprompt with the provided reprompt speech. If repromptSpeechOutput is an array,
+     * pick one of the strings randomly.
      * @param {string} repromptSpeechOutput
      * @returns {ResponseBuilder}
      */
-    reprompt(repromptSpeechOutput : string) : this;
+    reprompt(repromptSpeechOutput : string | string[]) : this;
     /**
      * Renders a simple card with the following title and content
      * @param {string} cardTitle

--- a/ask-sdk-core/lib/response/ResponseFactory.ts
+++ b/ask-sdk-core/lib/response/ResponseFactory.ts
@@ -71,22 +71,26 @@ export class ResponseFactory {
         }
 
         return {
-            speak(speechOutput : string) : ResponseBuilder {
+            speak(speechOutput : string | string[]) : ResponseBuilder {
+                const speech : string = Array.isArray(speechOutput) ? speechOutput[Math.floor(Math.random() * speechOutput.length)] : speechOutput;
+
                 response.outputSpeech = {
                     type : 'SSML',
                     ssml : '<speak>'
-                           + trimOutputSpeech(speechOutput)
+                           + trimOutputSpeech(speech)
                            + '</speak>',
                 };
 
                 return this;
             },
-            reprompt(repromptSpeechOutput : string) : ResponseBuilder {
+            reprompt(repromptSpeechOutput : string | string[]) : ResponseBuilder {
+                const speech : string = Array.isArray(repromptSpeechOutput) ? repromptSpeechOutput[Math.floor(Math.random() * repromptSpeechOutput.length)] : repromptSpeechOutput;
+
                 response.reprompt = {
                     outputSpeech : {
                         type : 'SSML',
                         ssml : '<speak>'
-                               + trimOutputSpeech(repromptSpeechOutput)
+                               + trimOutputSpeech(speech)
                                + '</speak>',
                     },
                 };

--- a/ask-sdk-core/tst/response/ResponseFactory.spec.ts
+++ b/ask-sdk-core/tst/response/ResponseFactory.spec.ts
@@ -13,7 +13,7 @@
 
 'use strict';
 
-import { interfaces } from 'ask-sdk-model';
+import {interfaces, ui} from 'ask-sdk-model';
 import { expect } from 'chai';
 import { ImageHelper } from '../../lib/response/ImageHelper';
 import { ResponseBuilder } from '../../lib/response/ResponseBuilder';
@@ -24,6 +24,7 @@ import PlayBehavior = interfaces.audioplayer.PlayBehavior;
 import ClearBehavior = interfaces.audioplayer.ClearBehavior;
 import Image = interfaces.display.Image;
 import BodyTemplate1 = interfaces.display.BodyTemplate1;
+import SsmlOutputSpeech = ui.SsmlOutputSpeech;
 
 describe('ResponseFactory', () => {
 
@@ -54,6 +55,15 @@ describe('ResponseFactory', () => {
         expect(responseBuilder.speak(speechOutput2).getResponse()).to.deep.equal(expectResponse);
     });
 
+    it('should build random response with with array as outputSpeech', () => {
+        const responseBuilder : ResponseBuilder = ResponseFactory.init();
+        const speechOutput = ['HelloWorld!', 'Good day!'];
+        const expectResponse = speechOutput.map((text) => `<speak>${text}</speak>`);
+
+        const {outputSpeech} = responseBuilder.speak(speechOutput).getResponse();
+        expect((outputSpeech as SsmlOutputSpeech).ssml).to.oneOf(expectResponse);
+    });
+
     it('should build response with Ssml reprompt', () => {
         const responseBuilder : ResponseBuilder = ResponseFactory.init();
         const speechOutput = 'HelloWorld!';
@@ -68,6 +78,15 @@ describe('ResponseFactory', () => {
             };
 
         expect(responseBuilder.reprompt(speechOutput).getResponse()).to.deep.equal(expectResponse);
+    });
+
+    it('should build random response with with array as reprompt', () => {
+        const responseBuilder : ResponseBuilder = ResponseFactory.init();
+        const speechOutput = ['HelloWorld!', 'Good day!'];
+        const expectResponse = speechOutput.map((text) => `<speak>${text}</speak>`);
+
+        const {reprompt} = responseBuilder.reprompt(speechOutput).getResponse();
+        expect((reprompt.outputSpeech as SsmlOutputSpeech).ssml).to.oneOf(expectResponse);
     });
 
     it('should build response with simple card', () => {


### PR DESCRIPTION
This change adds the possibility to specify an array of strings to the `speak` and `reprompt` methods of the `ResponseBuilder`. The SDK will then pick one of the strings randomly. This provides a convenient way of improving the UX by varying the sentences sent to the user and get a more human feeling.

## Description
see above

## Motivation and Context
Better UX for the user in an easy way

## Testing
Added unit tests for providing arrays to `speak` and `reprompt`

## Screenshots (if appropriate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
