### PR TITLE
package.json main should be dist/index.js

### DIFF
--- a/ask-sdk-core/package.json
+++ b/ask-sdk-core/package.json
@@ -2,7 +2,7 @@
   "name": "ask-sdk-core",
   "version": "2.0.1",
   "description": "Core package for Alexa Skills Kit SDK",
-  "main": "index.js",
+  "main": "dist/index.js",
   "types": "index.d.ts",
   "scripts": {
     "default": "gulp"


### PR DESCRIPTION
When running npm link locally after running `npm gulp` - the main is dist/index.js and not index.js

## Motivation and Context
This change fixes an issue when trying to use this package locally.  After running `npm gulp` script the main entrypoint is at dist/index.js instead of index.js

## License

- [ x ] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
