### PR TITLE
bug fix: correctly refer to the handlers dynamo db client

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -255,7 +255,7 @@ module.exports = (function () {
             }
 
             if(this.handler.saveBeforeResponse || forceSave || this.handler.response.response.shouldEndSession) {
-                attributesHelper(this.dynamoDBClient).set(this.handler.dynamoDBTableName, userId, this.attributes,
+                attributesHelper(this.handler.dynamoDBClient).set(this.handler.dynamoDBTableName, userId, this.attributes,
                     (err) => {
                         if(err) {
                             return this.emit(':saveStateError', err);


### PR DESCRIPTION
There is bug that prevents the alexa-sdk kit from putting attributes to a DynamoDB table.  This will fix the bug. 

## Description
The alexa-sdk saves attributes to a dynamodb for a client.  When the client provides a dynamoDB client to the alexa-sdk, the sdk should use that client in table puts.  There is a bug that prevents the kit from using the client's dynamo db kit in puts.  This will fix it.  The dynamodb client hangs off the handler.  So I refer to the handler.  The dynamo client never exists of 'this.'  So it's easy to fix.

## Motivation and Context
The motivation is to enable local developing of Alexa skills off the cloud.  For example, with Amazon's serverless application model ([sam](https://github.com/awslabs/aws-sam-local)) cli and the local dynamo db java app from aws. 
🍀I found this bug when developing a fix for a published Alexa skill, [Irish Clover Buttons](https://www.amazon.com/css-Irish-Clover-Buttons/dp/B07BPGDNCK).  The skill saves attributes to a dynamo db table. In production, the skill uses a dynamodb table in the cloud. To test my skill's bug fix, I ran the Alexa skill off the cloud with the sam cli.  

## Testing
I ran executed an Alexa skill locally with sam.  Verified that the sdk will create rows in a local dynamodb table.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

Example alexa skill code with a local dynamo db table:

```
const AWS = require('aws-sdk');
const dynamodb = new AWS.DynamoDB({endpoint:'http://host.docker.internal:8000'});
const alexa = Alexa.handler(event, context, callback);
alexa.dynamoDBClient = dynamodb;
alexa.dynamoDBTableName = 'irish-clover-local';
alexa.saveBeforeResponse=true;
```

## Checklist
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement