### PR TITLE
fix: small typo "DynamoDbPersistentAdapter"

### DIFF
--- a/docs/ja/Skill-Builders.rst
+++ b/docs/ja/Skill-Builders.rst
@@ -39,7 +39,7 @@ Custom Skill Builder
 Standard Skill Builder
 ----------------------
 
-``StandardSkillBuilder``\ は\ ``ask-sdk``\ パッケージでのみ使用できます。SDKのすべての機能を制限なしで使えるようにするために、\ ``DynamoDbPersistentAdapter``\ と\ ``DefaultApiClient``\ を使用します。また、Dynamo
+``StandardSkillBuilder``\ は\ ``ask-sdk``\ パッケージでのみ使用できます。SDKのすべての機能を制限なしで使えるようにするために、\ ``DynamoDbPersistenceAdapter``\ と\ ``DefaultApiClient``\ を使用します。また、Dynamo
 DBテーブルオプションを設定するヘルパー関数も提供します。
 
 **インターフェース**


### PR DESCRIPTION
## Description
The small typo "DynamoDbPersistentAdapter" has been fixed in the following issues.
https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/issues/360

The English document has been fixed, but the Japanese document has not been fixed.
I fixed same typo in the Japanese document.

## Motivation and Context
I thought this typo it would lead to mistakes in searching and coding.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
