### PR TITLE
docs: adding reminders API Javascript code sample

### DIFF
--- a/docs/en/Calling-Alexa-Service-APIs.rst
+++ b/docs/en/Calling-Alexa-Service-APIs.rst
@@ -654,11 +654,11 @@ The following example shows a request handler that creates an instance of the ``
 			.speak(speechText)
 			.getResponse();
 
-		} catch (error) {
-		console.error(error);
-		return responseBuilder
+		    } catch (error) {
+		    console.error(error);
+		    return responseBuilder
 			.speak('Uh Oh. Looks like something went wrong.')
 			.getResponse();
-		}
+		    }
 	    }
 	};

--- a/docs/en/Calling-Alexa-Service-APIs.rst
+++ b/docs/en/Calling-Alexa-Service-APIs.rst
@@ -654,11 +654,11 @@ The following example shows a request handler that creates an instance of the ``
 			.speak(speechText)
 			.getResponse();
 
-		    } catch (error) {
+		} catch (error) {
 		    console.error(error);
 		    return responseBuilder
 			.speak('Uh Oh. Looks like something went wrong.')
 			.getResponse();
-		    }
+		}
 	    }
 	};

--- a/docs/en/Calling-Alexa-Service-APIs.rst
+++ b/docs/en/Calling-Alexa-Service-APIs.rst
@@ -602,3 +602,63 @@ Type Definition
       getReminders(): Promise<services.reminderManagement.GetRemindersResponse>;
       createReminder(reminderRequest: services.reminderManagement.ReminderRequest): Promise<services.reminderManagement.ReminderResponse>;
     }
+
+Code Sample
+-----------
+
+The following example shows a request handler that creates an instance of the ``ReminderManagementServiceClient`` and creates a new reminder.
+
+.. code-block:: javascript
+
+	const CreateReminderIntent = {
+	    canHandle(handlerInput) {
+		const { request } = handlerInput.requestEnvelope;
+		return request.type === 'IntentRequest' && request.intent.name === 'CreateReminderIntent';
+	    },
+	    async handle(handlerInput) {
+		const { requestEnvelope, serviceClientFactory, responseBuilder } = handlerInput;
+		const consentToken = requestEnvelope.context.System.user.permissions
+		    && requestEnvelope.context.System.user.permissions.consentToken;
+		if (!consentToken) {
+		    return responseBuilder
+			.speak('Please enable Reminder permissions in the Amazon Alexa app.')
+			.withAskForPermissionsConsentCard(['alexa::alerts:reminders:skill:readwrite'])
+			.getResponse();
+		}
+
+		try {
+		    const speechText = "Great! I've scheduled a reminder for you.";
+
+		    const ReminderManagementServiceClient = serviceClientFactory.getReminderManagementServiceClient();
+		    const reminderPayload = {
+			"trigger": {
+			    "type": "SCHEDULED_RELATIVE",
+			    "offsetInSeconds": "30",
+			    "timeZoneId": "America/Los_Angeles"
+			},
+			"alertInfo": {
+			    "spokenInfo": {
+				"content": [{
+				    "locale": "en-US",
+				    "text": "walk the dog"
+				}]
+			    }
+			},
+			"pushNotification": {
+			    "status": "ENABLED"
+			}
+		    };
+
+		    await ReminderManagementServiceClient.createReminder(reminderPayload);
+		    return responseBuilder
+			.speak(speechText)
+			.getResponse();
+
+		} catch (error) {
+		console.error(error);
+		return responseBuilder
+			.speak('Uh Oh. Looks like something went wrong.')
+			.getResponse();
+		}
+	    }
+	};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adding a code sample is Javascript for creating an in-session reminder using the ReminderManagementServiceClient.

## Description
Creating an intent which creates an instance of the ReminderManagementServiceClient. It will first check to see if the customer has enabled the reminders permission for the skill. If not, the skill will return a home card and message prompting the customer to enable the permission.

## Motivation and Context
I have seen a couple of developer issues arise related to this topic, where an example would help solve their issue.

## Testing
I added this intent to a sample skill, and test with both the required permission enabled and disabled.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x ] My change requires a change to the documentation
- [x ] I have updated the documentation accordingly
- [x ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x ] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License
- [x ] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
