### PR TITLE
docs: correct spelling of utilities

### DIFF
--- a/docs/en/Configuring-Skill-Instance.rst
+++ b/docs/en/Configuring-Skill-Instance.rst
@@ -5,7 +5,7 @@ Configuring Skill Instance
 Skill
 =====
 
-The ``Skill`` object is the integration of all your skill logic. It is responsible for initializing SDK utilties such as the ``AttributesManager`` and ``ServiceClientFactory`` and also kick off the request handling process.
+The ``Skill`` object is the integration of all your skill logic. It is responsible for initializing SDK utilities such as the ``AttributesManager`` and ``ServiceClientFactory`` and also kick off the request handling process.
 
 Available Methods
 -----------------


### PR DESCRIPTION
## Description
Fixed the typo in the docs from utilties to utilities in Configuring Skill Instance

## Motivation and Context
It just fixes the documentation, to be clear.

## Testing
No need for testing.

## Screenshots (if appropriate)
-

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Docs(Add new document content)
- [ ] Translate Docs(Translate document content)

## Checklist
- [ ] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement