### PR TITLE
feat: add new util function (getRequest)

### DIFF
--- a/ask-sdk-core/lib/index.ts
+++ b/ask-sdk-core/lib/index.ts
@@ -56,6 +56,7 @@ export {
     getDialogState,
     getIntentName,
     getLocale,
+    getRequest,
     getRequestType,
     getSlot,
     getSlotValue,

--- a/ask-sdk-core/lib/util/RequestEnvelopeUtils.ts
+++ b/ask-sdk-core/lib/util/RequestEnvelopeUtils.ts
@@ -13,6 +13,7 @@
 
 import {
     IntentRequest,
+    Request,
     RequestEnvelope,
     Session,
     Slot,
@@ -63,6 +64,22 @@ export function getIntentName(requestEnvelope : RequestEnvelope) : string {
     throw createAskSdkError(
         'RequestEnvelopeUtils',
         `Expecting request type of IntentRequest but got ${getRequestType(requestEnvelope)}.`);
+}
+
+/**
+ * Get request object.
+ *
+ * We can set a specific type to the response by using the generics
+ * @param {RequestEnvelope} requestEnvelope
+ * @return {Request}
+ * @example
+ * ```
+ * const intentRequest = getRequest<IntentRequest>(requestEnvelope)
+ * console.log(intentRequest.intent.name)
+ * ```
+ */
+export function getRequest <T extends Request> (requestEnvelope : RequestEnvelope) : T {
+    return requestEnvelope.request as T;
 }
 
 /**

--- a/ask-sdk-core/tst/util/RequestEnvelopeUtil.spec.ts
+++ b/ask-sdk-core/tst/util/RequestEnvelopeUtil.spec.ts
@@ -91,16 +91,25 @@ describe('RequestEnvelopeUtils', () => {
     it('should return the intent request object', () => {
         const request = getRequest<IntentRequest>(intentRequestEnvelope)
         expect(request).deep.eq({
-            "type":"IntentRequest",
-            "requestId":null,
-            "timestamp":null,
-            "locale":null,
-            "intent":{
-                "confirmationStatus":null,
-                "name":"MockIntent",
-                "slots":{
-                    "mockSlot":{"confirmationStatus":null,"name":"mockSlot","value":"mockSlotValue","resolutions":null}}},"dialogState":"STARTED"})
-    })
+            type: 'IntentRequest',
+            requestId: null,
+            timestamp: null,
+            locale: null,
+            intent: {
+                confirmationStatus: null,
+                name: 'MockIntent',
+                slots: {
+                    mockSlot: {
+                        confirmationStatus: null,
+                        name: 'mockSlot',
+                        value: 'mockSlotValue',
+                        resolutions: null,
+                    },
+                },
+            },
+            dialogState: 'STARTED',
+        });
+    });
 
     it('should be able to get account linking access token', () => {
         expect(getAccountLinkingAccessToken(requestEnvelope)).eq('mockAccessToken');

--- a/ask-sdk-core/tst/util/RequestEnvelopeUtil.spec.ts
+++ b/ask-sdk-core/tst/util/RequestEnvelopeUtil.spec.ts
@@ -24,6 +24,7 @@ import {
     getUserId,
     getDialogState,
     getIntentName,
+    getRequest,
     getLocale,
     getRequestType,
     getSlot,
@@ -86,6 +87,20 @@ describe('RequestEnvelopeUtils', () => {
             getIntentName(requestEnvelope);
         }).to.throw(`Expecting request type of IntentRequest but got LaunchRequest.`);
     });
+
+    it('should return the intent request object', () => {
+        const request = getRequest<IntentRequest>(intentRequestEnvelope)
+        expect(request).deep.eq({
+            "type":"IntentRequest",
+            "requestId":null,
+            "timestamp":null,
+            "locale":null,
+            "intent":{
+                "confirmationStatus":null,
+                "name":"MockIntent",
+                "slots":{
+                    "mockSlot":{"confirmationStatus":null,"name":"mockSlot","value":"mockSlotValue","resolutions":null}}},"dialogState":"STARTED"})
+    })
 
     it('should be able to get account linking access token', () => {
         expect(getAccountLinkingAccessToken(requestEnvelope)).eq('mockAccessToken');

--- a/ask-sdk/lib/index.ts
+++ b/ask-sdk/lib/index.ts
@@ -33,6 +33,7 @@ export {
     getDialogState,
     getIntentName,
     getLocale,
+    getRequest,
     getRequestType,
     getSlot,
     getSlotValue,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The `getRequest()` function helps us to make a skill by using TypeScript.
We can get a specific type of the request object. 

## Description
Add a new util function `getRequest`.
To get request object with own expected type.

## Motivation and Context
Related: Missing typescript definitions? #398

### Currently
We can get the request object by the code.

```typescript
const { request} = handlerInput.requestEnvelope
```

But the object has several type, so we can not get any property without using `any`.

```typescript
// ERROR
const state = handlerInput.requestEnvelope.request.dialogState

-> Property 'dialogState' does not exist on type 'PlaybackFinishedRequest'.

// PASS
const state = (handlerInput.requestEnvelope.request as IntentRequest).dialogState
```

But these coding style is not comfortable and hard to understand for a new developer.

### Solution

The `getRequest` function is my solution.
It can update the `request` object type by using TypeScript Generics.

```typescript
// For Intent request
const request = getRequest<IntentRequest>(handlerInput.requestEnvelope)
const state = request.dialogState

// For AudioPlayer intent request
const req = getRequest<interfaces.audioplayer.PlaybackFinishedRequest>(intentRequestEnvelope)
const sec = req.offsetInMilliseconds
```

## Testing

```
$ lerna --scope ask-sdk-core run gulp

  113 passing (101ms)


=============================== Coverage summary ===============================
Statements   : 100% ( 357/357 )
Branches     : 98.99% ( 98/99 )
Functions    : 96.33% ( 105/109 )
Lines        : 100% ( 336/336 )
================================================================================

[00:17:25] Finished 'test' after 2.59 s
[00:17:26] Finished 'tsc' after 3.58 s
[00:17:26] Finished 'default' after 3.6 s
lerna success run Ran npm script 'gulp' in 1 package in 5.4s:
lerna success - ask-sdk-core
```

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs(Add new document content)
- [ ] Translate Docs(Translate document content)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
