### PR TITLE
fix: Retrieve case-insensitive header values

### DIFF
--- a/ask-sdk-express-adapter/CHANGELOG.md
+++ b/ask-sdk-express-adapter/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Change Log
+
+# 2.0.1 (2020-01-22)
+
+This release contains the following changes : 
+
+- Case-insensitive header value retrieval for request verification. [604](https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/issues/604)

--- a/ask-sdk-express-adapter/lib/verifier/index.ts
+++ b/ask-sdk-express-adapter/lib/verifier/index.ts
@@ -73,9 +73,10 @@ export class SkillRequestSignatureVerifier implements Verifier {
         let signatureCertChainUrl : string;
         let signature : string;
         for (const keys of Object.keys(headers)) {
-            if (keys.toLocaleLowerCase() === SIGNATURE_CERT_CHAIN_URL_HEADER.toLowerCase()) {
+            const keysInLowerCase = keys.toLocaleLowerCase();
+            if (keysInLowerCase === SIGNATURE_CERT_CHAIN_URL_HEADER.toLowerCase()) {
                 signatureCertChainUrl = headers[keys] as string;
-            } else if (keys.toLocaleLowerCase() === SIGNATURE_HEADER.toLowerCase()) {
+            } else if (keysInLowerCase === SIGNATURE_HEADER.toLowerCase()) {
                 signature = headers[keys] as string;
             }
         }

--- a/ask-sdk-express-adapter/lib/verifier/index.ts
+++ b/ask-sdk-express-adapter/lib/verifier/index.ts
@@ -72,12 +72,12 @@ export class SkillRequestSignatureVerifier implements Verifier {
         // throw error if signature or signatureCertChainUrl are not present
         let signatureCertChainUrl : string;
         let signature : string;
-        for (const keys of Object.keys(headers)) {
-            const keysInLowerCase = keys.toLocaleLowerCase();
-            if (keysInLowerCase === SIGNATURE_CERT_CHAIN_URL_HEADER.toLowerCase()) {
-                signatureCertChainUrl = headers[keys] as string;
-            } else if (keysInLowerCase === SIGNATURE_HEADER.toLowerCase()) {
-                signature = headers[keys] as string;
+        for (const key of Object.keys(headers)) {
+            const keyInLowerCase = key.toLocaleLowerCase();
+            if (keyInLowerCase === SIGNATURE_CERT_CHAIN_URL_HEADER.toLowerCase()) {
+                signatureCertChainUrl = headers[key] as string;
+            } else if (keyInLowerCase === SIGNATURE_HEADER.toLowerCase()) {
+                signature = headers[key] as string;
             }
         }
 

--- a/ask-sdk-express-adapter/lib/verifier/index.ts
+++ b/ask-sdk-express-adapter/lib/verifier/index.ts
@@ -70,8 +70,16 @@ export class SkillRequestSignatureVerifier implements Verifier {
      */
     public async verify (requestEnvelope : string, headers : IncomingHttpHeaders) : Promise<void> {
         // throw error if signature or signatureCertChainUrl are not present
-        const signatureCertChainUrl : string = headers[SIGNATURE_CERT_CHAIN_URL_HEADER.toLowerCase()] as string;
-        const signature : string = headers[SIGNATURE_HEADER.toLowerCase()] as string;
+        let signatureCertChainUrl : string;
+        let signature : string;
+        for (const keys of Object.keys(headers)) {
+            if (keys.toLocaleLowerCase() === SIGNATURE_CERT_CHAIN_URL_HEADER.toLowerCase()) {
+                signatureCertChainUrl = headers[keys] as string;
+            } else if (keys.toLocaleLowerCase() === SIGNATURE_HEADER.toLowerCase()) {
+                signature = headers[keys] as string;
+            }
+        }
+
         if (!signatureCertChainUrl) {
             throw createAskSdkError(
                 this.constructor.name,

--- a/ask-sdk-express-adapter/package.json
+++ b/ask-sdk-express-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ask-sdk-express-adapter",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Express adapter package for Alexa Skills Kit SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/ask-sdk-express-adapter/tst/verifier/index.spec.ts
+++ b/ask-sdk-express-adapter/tst/verifier/index.spec.ts
@@ -164,6 +164,22 @@ describe('SkillRequestSignatureVerifier', () => {
                 expect.fail('should not throw error');
             }
         });
+
+        it('should not throw error when header keys are in camel case', async() => {
+            const validRequestBody : string = fs.readFileSync(__dirname + '/../mocks/requestEnvelope.json').toString();
+            const requestHeader : IncomingHttpHeaders = DataProvider.requestHeader();
+            const signatureKeyInCamel = 'Signature';
+            const urlKeyInCamel = 'SignatureCertChainUrl';
+            requestHeader[signatureKeyInCamel] = validSignature;
+            requestHeader[urlKeyInCamel] = testUrl;
+            nock('https://s3.amazonaws.com').get(certUrl.path).reply(200, validPem);
+            sinon.stub(verifier, <any> '_validateRequestBody');
+            try {
+                await verifier.verify(validRequestBody, requestHeader);
+            } catch (err) {
+                expect.fail('should not throw error');
+            }
+        });
     });
 
     describe('async function _validateUrlAndRetriveCertChain', () => {


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
Since header keys can be case-insensitive as per the RFC 2616 doc, we need to retrieve them correctly before retrieving the certificate for request verification.

## Testing
Unit tests run successfully.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs(Add new document content)
- [ ] Translate Docs(Translate document content)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
