### PR TITLE
feat: add a defaultAttributes parameter in getPersistentAttributes

### DIFF
--- a/ask-sdk-core/lib/attributes/AttributesManager.ts
+++ b/ask-sdk-core/lib/attributes/AttributesManager.ts
@@ -30,7 +30,7 @@ export interface AttributesManager {
      * @param {boolean} [useSessionCache=true]
      * @returns {Promise<Object.<string, any>>}
      */
-    getPersistentAttributes(useSessionCache? : boolean) : Promise<{[key : string] : any}>;
+    getPersistentAttributes(useSessionCache? : boolean, defaultAttribuets?: {[key: string]: any}) : Promise<{[key : string] : any}>;
     /**
      * Overwrites the request attributes value.
      * @param {Object.<string, any>} requestAttributes

--- a/ask-sdk-core/lib/attributes/AttributesManagerFactory.ts
+++ b/ask-sdk-core/lib/attributes/AttributesManagerFactory.ts
@@ -53,7 +53,7 @@ export class AttributesManagerFactory {
 
                 return thisSessionAttributes as T;
             },
-            async getPersistentAttributes(useSessionCache : boolean = true) : Promise<{[key : string] : any}> {
+            async getPersistentAttributes(useSessionCache : boolean = true, defaultAttributes?: {[key: string]: any}) : Promise<{[key : string] : any}> {
                 if (!options.persistenceAdapter) {
                     throw createAskSdkError(
                         'AttributesManager',
@@ -63,6 +63,9 @@ export class AttributesManagerFactory {
                 if (!persistentAttributesSet || !useSessionCache) {
                     thisPersistentAttributes = await options.persistenceAdapter.getAttributes(options.requestEnvelope);
                     persistentAttributesSet = true;
+                }
+                if (defaultAttributes && (!thisPersistentAttributes || Object.keys(thisPersistentAttributes).length < 1)) {
+                    thisPersistentAttributes = defaultAttributes
                 }
 
                 return thisPersistentAttributes;

--- a/ask-sdk-core/tst/attributes/AttributesManagerFactory.spec.ts
+++ b/ask-sdk-core/tst/attributes/AttributesManagerFactory.spec.ts
@@ -64,6 +64,21 @@ describe('AttributesManagerFactory', () => {
         throw new Error('should have thrown an error!');
     });
 
+    it('should get default attributes when db has no attributes', async() => {
+        const requestEnvelope = JsonProvider.requestEnvelope();
+        requestEnvelope.context.System.user.userId = 'userId';
+        const defaultAttributesManager = AttributesManagerFactory.init({
+            persistenceAdapter : new MockPersistenceAdapter(),
+            requestEnvelope,
+        });
+        await defaultAttributesManager.deletePersistentAttributes();
+        expect(await defaultAttributesManager.getPersistentAttributes(true, {
+            key_1: 'v1',
+        })).deep.equal({
+            key_1 : 'v1',
+        });
+    });
+
     it('should be able to get persistent attributes', async() => {
         const requestEnvelope = JsonProvider.requestEnvelope();
         requestEnvelope.context.System.user.userId = 'userId';


### PR DESCRIPTION
## Description

To add a new parameter named `defaultAttributes`.
We can easy to initialize persistence attributes to use it.

## Motivation and Context

### Before

We have to initialize persistence attributes by own code.

```typescript
let attributes = await attributesManager.getPersistentAttributes()
if (!attributes) {
  attributes = {
    invocationCount: 1
  }
  attributesManager.setPersistenceAttributes(attributes)
}
```

### After

We can easy to initialize the attributes

```typescript
const attributes = await attributesManager.getPersistentAttributes(true, { invocationCount: 1 } )
```

## Testing

See my test code in this PR.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs(Add new document content)
- [ ] Translate Docs(Translate document content)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
