### PR TITLE
feat: add UserAgentManager

### DIFF
--- a/ask-sdk-core/tst/skill/CustomSkill.spec.ts
+++ b/ask-sdk-core/tst/skill/CustomSkill.spec.ts
@@ -12,6 +12,7 @@
  */
 
 import { ui } from 'ask-sdk-model';
+import { UserAgentManager } from 'ask-sdk-runtime';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { HandlerInput } from '../../lib/dispatcher/request/handler/HandlerInput';
@@ -19,6 +20,10 @@ import { SkillBuilders } from '../../lib/skill/SkillBuilders';
 import { JsonProvider } from '../mocks/JsonProvider';
 import { MockAlwaysFalseRequestHandler } from '../mocks/request/MockAlwaysFalseRequestHandler';
 import { MockAlwaysTrueRequestHandler } from '../mocks/request/MockAlwaysTrueRequestHandler';
+
+beforeEach(function() {
+    UserAgentManager.clear();
+});
 
 describe('CustomSkill', () => {
     it('should be able to send RequestEnvelope and context to RequestDispatcher', async () => {
@@ -181,7 +186,7 @@ describe('CustomSkill', () => {
     });
 
     it('should be able to append additional user agent', async () => {
-        const additionUserAnger : string = 'TEST_Agent';
+        const additionalUserAgent : string = 'TEST_Agent';
         const packageInfo = require('../../package.json');
         const skill = SkillBuilders.custom()
             .withCustomUserAgent('custom')
@@ -192,14 +197,14 @@ describe('CustomSkill', () => {
             .create();
 
         const requestEnvelope = JsonProvider.requestEnvelope();
-        skill.appendAdditionalUserAgent(additionUserAnger);
+        skill.appendAdditionalUserAgent(additionalUserAgent);
         const responseEnvelope = await skill.invoke(requestEnvelope);
 
-        expect(responseEnvelope.userAgent).equal(`ask-node/${packageInfo.version} Node/${process.version} custom ${additionUserAnger}`);
+        expect(responseEnvelope.userAgent).equal(`ask-node/${packageInfo.version} Node/${process.version} custom ${additionalUserAgent}`);
     });
 
     it('should be able to append additional user agent', async () => {
-        const additionUserAnger : string = 'TEST_Agent';
+        const additionalUserAgent : string = 'TEST_Agent';
         const packageInfo = require('../../package.json');
         const skill = SkillBuilders.custom()
             .addRequestHandlers(
@@ -209,9 +214,26 @@ describe('CustomSkill', () => {
             .create();
 
         const requestEnvelope = JsonProvider.requestEnvelope();
-        skill.appendAdditionalUserAgent(additionUserAnger);
+        skill.appendAdditionalUserAgent(additionalUserAgent);
         const responseEnvelope = await skill.invoke(requestEnvelope);
 
-        expect(responseEnvelope.userAgent).equal(`ask-node/${packageInfo.version} Node/${process.version} ${additionUserAnger}`);
+        expect(responseEnvelope.userAgent).equal(`ask-node/${packageInfo.version} Node/${process.version} ${additionalUserAgent}`);
+    });
+
+    it('should append user agent component added through the UserAgentManager', async () => {
+        const additionalUserAgent : string = 'TEST_Agent';
+        const packageInfo = require('../../package.json');
+        const skill = SkillBuilders.custom()
+            .addRequestHandlers(
+                new MockAlwaysTrueRequestHandler(),
+                new MockAlwaysFalseRequestHandler(),
+            )
+            .create();
+
+        const requestEnvelope = JsonProvider.requestEnvelope();
+        UserAgentManager.registerComponent(additionalUserAgent);
+        const responseEnvelope = await skill.invoke(requestEnvelope);
+
+        expect(responseEnvelope.userAgent).equal(`ask-node/${packageInfo.version} Node/${process.version} ${additionalUserAgent}`);
     });
 });

--- a/ask-sdk-runtime/lib/index.ts
+++ b/ask-sdk-runtime/lib/index.ts
@@ -34,3 +34,5 @@ export {
     createAskSdkError,
     createAskSdkUserAgent
 } from './util/AskSdkUtils';
+
+export { UserAgentManager } from './util/UserAgentManager';

--- a/ask-sdk-runtime/lib/util/AskSdkUtils.ts
+++ b/ask-sdk-runtime/lib/util/AskSdkUtils.ts
@@ -31,7 +31,7 @@ export function createAskSdkError(errorScope: string, errorMessage: string): Err
  * @param packageVersion
  * @param customUserAgent
  */
-export function createAskSdkUserAgent(packageVersion: string, customUserAgent: string): string {
+export function createAskSdkUserAgent(packageVersion: string, customUserAgent?: string): string {
     const customUserAgentString = customUserAgent ? (` ${ customUserAgent}`) : '';
 
     return `ask-node/${packageVersion} Node/${process.version}${ customUserAgentString}`;

--- a/ask-sdk-runtime/lib/util/UserAgentManager.ts
+++ b/ask-sdk-runtime/lib/util/UserAgentManager.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * Static manager of environment level SDK user agent information.
+ */
+export class UserAgentManager {
+
+    private static components: Set<string> = new Set();
+    private static userAgent: string = '';
+
+    /**
+     * Retrieves the full user agent string, containing all registered components.
+     */
+    static getUserAgent(): string {
+        return this.userAgent;
+    }
+
+    /**
+     * Registers a user agent component. This will be appended to the generated
+     * user agent string. Duplicate components will be ignored.
+     *
+     * @param component string component to add to the full user agent
+     */
+    static registerComponent(component: string): void {
+        if (!this.components.has(component)) {
+            this.components.add(component);
+            let updatedUserAgent: string;
+            for (const component of this.components) {
+                updatedUserAgent = updatedUserAgent ? `${updatedUserAgent} ${component}` : component;
+            }
+            this.userAgent = updatedUserAgent;
+        }
+    }
+
+    /**
+     * Clears any existing components from the user agent and resets it to empty.
+     */
+    static clear() {
+        this.components.clear();
+        this.userAgent = '';
+    }
+
+}

--- a/ask-sdk-runtime/tst/util/UserAgentManager.spec.ts
+++ b/ask-sdk-runtime/tst/util/UserAgentManager.spec.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { UserAgentManager } from '../../lib/util/UserAgentManager';
+
+describe('UserAgentManager', () => {
+    it('should be initialized with an empty string', () => {
+        expect(UserAgentManager.getUserAgent()).equal('');
+    });
+
+    it('should handle a single component', () => {
+        UserAgentManager.registerComponent('foo');
+        expect(UserAgentManager.getUserAgent()).equal('foo');
+    });
+
+    it('should handle multiple components', () => {
+        UserAgentManager.registerComponent('foo');
+        UserAgentManager.registerComponent('bar');
+        expect(UserAgentManager.getUserAgent()).equal('foo bar');
+    });
+
+    it('should clear components', () => {
+        UserAgentManager.registerComponent('foo');
+        UserAgentManager.registerComponent('bar');
+        UserAgentManager.clear();
+        expect(UserAgentManager.getUserAgent()).equal('');
+    });
+});


### PR DESCRIPTION
## Description
Adds a static UserAgentManager which manages environment level SDK user agent information. User agent component registration and full user agent string retrieval is encapsulated by this new class rather than being registered and computed at the CustomSkill layer.

The manager does not allow for duplicate user agent components and only computes an updated user agent string once per valid component addition. At request time, the precomputed value is used rather than the existing approach which required reconstruction per request.

## Motivation and Context
The primary motivation for this change is to allow other frameworks that are designed for use with the SDK, but may not directly be configured on the SDK instance itself, to register themselves with user agent components. With this singleton manager approach, such components can directly append a user agent component at runtime/request execution.

## Testing
Added tests for the UserAgentManager and an additional test for CustomSkill. Existing tests continue to pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs(Add new document content)
- [ ] Translate Docs(Translate document content)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
