### PR TITLE
fix: export UserAgentManager from core

### DIFF
--- a/ask-sdk-core/CHANGELOG.md
+++ b/ask-sdk-core/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.10.1](https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/compare/v2.9.0...v2.10.0) (2020-10-09)
+
+
+### Features
+
+* export UserAgentManager class in SDK core
+
+
+
+
+
 # [2.10.0](https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/compare/v2.9.0...v2.10.0) (2020-10-08)
 
 

--- a/ask-sdk-core/lib/index.ts
+++ b/ask-sdk-core/lib/index.ts
@@ -68,5 +68,6 @@ export {
 
 export {
     createAskSdkError,
-    createAskSdkUserAgent
+    createAskSdkUserAgent,
+    UserAgentManager
 } from 'ask-sdk-runtime';

--- a/ask-sdk-core/package.json
+++ b/ask-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ask-sdk-core",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Core package for Alexa Skills Kit SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -29,7 +29,7 @@
     "SDK"
   ],
   "dependencies": {
-    "ask-sdk-runtime": "^2.10.0"
+    "ask-sdk-runtime": "^2.10.1"
   },
   "peerDependencies": {
     "ask-sdk-model": "^1.29.0"

--- a/ask-sdk-core/tst/skill/CustomSkill.spec.ts
+++ b/ask-sdk-core/tst/skill/CustomSkill.spec.ts
@@ -22,7 +22,8 @@ import { MockAlwaysFalseRequestHandler } from '../mocks/request/MockAlwaysFalseR
 import { MockAlwaysTrueRequestHandler } from '../mocks/request/MockAlwaysTrueRequestHandler';
 
 beforeEach(function() {
-    UserAgentManager.clear();
+    UserAgentManager['components'].clear();
+    UserAgentManager['userAgent'] = '';
 });
 
 describe('CustomSkill', () => {

--- a/ask-sdk-runtime/CHANGELOG.md
+++ b/ask-sdk-runtime/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.10.1](https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/compare/v2.9.0...v2.10.0) (2020-10-09)
+
+
+### Bug Fixes
+
+* remove the clear function in UserAgentManager
+
+
+
+
+
+
 # [2.10.0](https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/compare/v2.9.0...v2.10.0) (2020-10-08)
 
 

--- a/ask-sdk-runtime/lib/util/UserAgentManager.ts
+++ b/ask-sdk-runtime/lib/util/UserAgentManager.ts
@@ -42,13 +42,4 @@ export class UserAgentManager {
             this.userAgent = updatedUserAgent;
         }
     }
-
-    /**
-     * Clears any existing components from the user agent and resets it to empty.
-     */
-    static clear() {
-        this.components.clear();
-        this.userAgent = '';
-    }
-
 }

--- a/ask-sdk-runtime/package.json
+++ b/ask-sdk-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ask-sdk-runtime",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Base runtime package for Alexa Skills Kit SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/ask-sdk-runtime/tst/util/UserAgentManager.spec.ts
+++ b/ask-sdk-runtime/tst/util/UserAgentManager.spec.ts
@@ -33,7 +33,8 @@ describe('UserAgentManager', () => {
     it('should clear components', () => {
         UserAgentManager.registerComponent('foo');
         UserAgentManager.registerComponent('bar');
-        UserAgentManager.clear();
+        UserAgentManager['components'].clear();
+        UserAgentManager['userAgent'] = '';
         expect(UserAgentManager.getUserAgent()).equal('');
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
* UserAgentManager  is not exported at core, thus skill would need to add direct dependency on runtime to user UserAgentManager
## Description
<!--- Describe your changes in detail -->
export UserAgentManager from core
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs(Add new document content)
- [ ] Translate Docs(Translate document content)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
