### PR TITLE
feat: Add support for non-serverless skill invocation

### DIFF
--- a/ask-sdk-local-debug/lib/LocalDebuggerInvoker.ts
+++ b/ask-sdk-local-debug/lib/LocalDebuggerInvoker.ts
@@ -35,14 +35,18 @@ const clientConfig = new ClientConfigBuilder()
 let skillInvokerConfig: SkillInvokerConfig;
 let remoteInvokerConfig: RemoteInvokerConfig;
 
-if (clientConfig.skillEntryFile !== '' && clientConfig.handlerName !== '') {
+// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+if (clientConfig.skillEntryFile && clientConfig.handlerName) {
   skillInvokerConfig = new SkillInvokerConfigBuilder()
     .withHandler(getHandlerFunction(clientConfig.skillEntryFile, clientConfig.handlerName))
     .build();
-} else if (clientConfig.remoteUrl !== '') {
+// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+} else if (clientConfig.remoteUrl) {
   remoteInvokerConfig = new RemoteInvokerConfigBuilder()
     .withRemoteUrl(clientConfig.remoteUrl)
     .build();
+} else {
+  throw new Error('Must provide skillEntryFile and handlerName, or a remoteUrl');
 }
 
 const webSocketClientConfig = new WebSocketClientConfigBuilder()

--- a/ask-sdk-local-debug/lib/builder/ClientConfigBuilder.ts
+++ b/ask-sdk-local-debug/lib/builder/ClientConfigBuilder.ts
@@ -24,6 +24,8 @@ export class ClientConfigBuilder {
 
     private _region: string;
 
+    private _remoteUrl: string;
+
     public withSkillEntryFile(skillEntryFile: string): ClientConfigBuilder {
         this._skillEntryFile = skillEntryFile;
 
@@ -54,6 +56,12 @@ export class ClientConfigBuilder {
         return this;
     }
 
+    public withRemoteUrl(remoteUrl: string): ClientConfigBuilder {
+        this._remoteUrl = remoteUrl;
+
+        return this;
+    }
+
     public get skillEntryFile(): string {
         return this._skillEntryFile;
     }
@@ -72,6 +80,10 @@ export class ClientConfigBuilder {
 
     public get region(): string {
         return this._region;
+    }
+
+    public get remoteUrl(): string {
+         return this._remoteUrl;
     }
 
     public build(): ClientConfig {

--- a/ask-sdk-local-debug/lib/builder/RemoteInvokerConfigBuilder.ts
+++ b/ask-sdk-local-debug/lib/builder/RemoteInvokerConfigBuilder.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License').
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the 'license' file accompanying this file. This file is distributed
+ * on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { RemoteInvokerConfig } from '../config/RemoteInvokerConfig';
+
+export class RemoteInvokerConfigBuilder {
+    private _url: string;
+
+    public withRemoteUrl(url: string): RemoteInvokerConfigBuilder {
+        this._url = url;
+
+        return this;
+    }
+
+    public get url(): string {
+        return this._url;
+   }
+
+    public build(): RemoteInvokerConfig {
+        return new RemoteInvokerConfig(this);
+    }
+}

--- a/ask-sdk-local-debug/lib/config/ClientConfig.ts
+++ b/ask-sdk-local-debug/lib/config/ClientConfig.ts
@@ -24,12 +24,15 @@ export class ClientConfig {
 
     private readonly _region: string;
 
+    private readonly _remoteUrl: string;
+
     constructor(clientConfigBuilder: ClientConfigBuilder) {
         this._skillEntryFile = clientConfigBuilder.skillEntryFile;
         this._handlerName = clientConfigBuilder.handlerName;
         this._accessToken = clientConfigBuilder.accessToken;
         this._skillId = clientConfigBuilder.skillId;
         this._region = clientConfigBuilder.region;
+        this._remoteUrl = clientConfigBuilder.remoteUrl;
     }
 
     public get skillEntryFile(): string {
@@ -50,5 +53,9 @@ export class ClientConfig {
 
     public get region(): string {
         return this._region;
+    }
+
+    public get remoteUrl(): string {
+      return this._remoteUrl;
     }
 }

--- a/ask-sdk-local-debug/lib/config/RemoteInvokerConfig.ts
+++ b/ask-sdk-local-debug/lib/config/RemoteInvokerConfig.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License').
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the 'license' file accompanying this file. This file is distributed
+ * on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { RemoteInvokerConfigBuilder } from '../builder/RemoteInvokerConfigBuilder';
+
+export class RemoteInvokerConfig {
+    public readonly _url: string;
+
+    constructor(remoteInvokerConfigBuilder: RemoteInvokerConfigBuilder) {
+        this._url = remoteInvokerConfigBuilder.url;
+    }
+
+    public get url(): string {
+        return this._url;
+    }
+}

--- a/ask-sdk-local-debug/lib/util/ArgsParserUtils.ts
+++ b/ask-sdk-local-debug/lib/util/ArgsParserUtils.ts
@@ -34,17 +34,18 @@ export function argsParser(): any {
       type: 'string',
       description:
         'Name of the handler function that will be invoked to run the skill code.',
-      demandOption: true,
-      requiresArg: true,
     },
     skillEntryFile: {
       type: 'string',
       description:
         'Path of the file in the skill code package where the handler function is located.',
-      demandOption: true,
-      requiresArg: true,
     },
     region: {
+      type: 'string',
+      description:
+        'Region of the developer account. TODO:: dev documentation link.',
+    },
+    remoteUrl: {
       type: 'string',
       description:
         'Region of the developer account. TODO:: dev documentation link.',
@@ -65,19 +66,8 @@ export function argsParser(): any {
       return true;
     })
     .check((argv) => {
-      if (argv.handlerName == null) {
-        console.error('Handler name cannot be null or empty.');
-        return false;
-      }
-      return true;
-    })
-    .check((argv) => {
-      if (argv.skillEntryFile == null) {
-        console.error('Skill entry file cannot be null or empty.');
-        return false;
-      }
-      if (!existsSync(argv.skillEntryFile)) {
-        console.error('Skill entry file does not  exist.');
+      if ((argv.handlerName == null || argv.skillEntryFile == null) && argv.remoteUrl == null) {
+        console.error('Must provide either skillEntryFile and handlerName, or a remoteUrl.');
         return false;
       }
       return true;

--- a/ask-sdk-local-debug/package.json
+++ b/ask-sdk-local-debug/package.json
@@ -37,10 +37,11 @@
     "typescript": "^3.9.5"
   },
   "dependencies": {
-    "ws": "^7.3.0",
-    "yargs": "^15.3.1",
-    "immutable": "^4.0.0-rc.11",
+    "ask-sdk-core": "^2.8.0",
     "ask-sdk-model": "^1.29.0",
-    "ask-sdk-core": "^2.8.0"
+    "axios": "^0.21.0",
+    "immutable": "^4.0.0-rc.11",
+    "ws": "^7.3.0",
+    "yargs": "^15.3.1"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Kind of a wonky hack, but essentially allows a skill hosted on a server to use the websocket service and intercept skill requests to a local development machine.

Probably not going to update this PR since I've got what I need working for my dev workflow, but feel free to run with this idea if y'all feel like it's worth supporting.

## Motivation and Context
Wanted to do some local development without needing to spin up ngrok and point the skill's endpoint to my ngrok URL all the time.

## Testing
Iterating on a skill with this setup

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs(Add new document content)
- [ ] Translate Docs(Translate document content)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [X] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [X] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
