### PR TITLE
Fix: responseBuilder.reprompt() clears APLA reprompt directives

### DIFF
--- a/ask-sdk-core/lib/response/ResponseFactory.ts
+++ b/ask-sdk-core/lib/response/ResponseFactory.ts
@@ -91,14 +91,16 @@ export class ResponseFactory {
                 return this;
             },
             reprompt(repromptSpeechOutput : string, playBehavior? : ui.PlayBehavior) : ResponseBuilder {
-                response.reprompt = {
-                    outputSpeech : {
-                        type : 'SSML',
-                        ssml : `<speak>${
-                            trimOutputSpeech(repromptSpeechOutput)
-                        }</speak>`,
-                        playBehavior,
-                    },
+                if (!response.reprompt) {
+                    response.reprompt = {};
+                }
+
+                response.reprompt.outputSpeech = {
+                    type : 'SSML',
+                    ssml : `<speak>${
+                        trimOutputSpeech(repromptSpeechOutput)
+                    }</speak>`,
+                    playBehavior,
                 };
 
                 if (!playBehavior) {

--- a/ask-sdk-core/tst/response/ResponseFactory.spec.ts
+++ b/ask-sdk-core/tst/response/ResponseFactory.spec.ts
@@ -851,6 +851,10 @@ describe('ResponseFactory', () => {
                 type: 'SSML',
             },
             reprompt : {
+                outputSpeech: {
+                    ssml: `<speak>${ speechOutput }</speak>`,
+                    type: 'SSML',
+                },
                 directives: [
                     {
                         type: 'Alexa.Presentation.APLA.RenderDocument',
@@ -866,6 +870,7 @@ describe('ResponseFactory', () => {
                 document : aplaDocument,
             })
             .speak(speechOutput)
+            .reprompt(speechOutput)
             .getResponse()).to.deep.equals(expectResponse);
     });
 


### PR DESCRIPTION
## Description
If using an APLA reprompt directive by calling addDirectiveToReprompt(), a future call to reprompt() removes all reprompt directives.

## Motivation and Context
It should not matter the order in which reprompt() and addDirectiveToReprompt() are called through the ResponseBuilder. 
This is related to the recent addition of #694 

## Testing
I updated the ResponseBuilder tests to contain both a reprompt outputSpeech as well as a directive. The order of the function calls in the tests are addDirectiveTooReprompt() first, then reprompt()

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs(Add new document content)
- [ ] Translate Docs(Translate document content)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License
- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
