### PR TITLE
feat(aws-sdk-s3-persistence-adapter, aws-sdk-dynamodb-persistence-adapter): upgrade dynamodb and s3 persistence adapters to use AWS SDK v3

### DIFF
--- a/ask-sdk-core/package.json
+++ b/ask-sdk-core/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@types/chai": "^4.1.2",
     "@types/mocha": "^5.0.0",
-    "@types/node": "^9.6.1",
+    "@types/node": "^12.0.0",
     "@types/sinon": "^7.0.13",
     "@typescript-eslint/eslint-plugin": "^3.9.0",
     "@typescript-eslint/parser": "^3.9.0",

--- a/ask-sdk-dynamodb-persistence-adapter/package.json
+++ b/ask-sdk-dynamodb-persistence-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ask-sdk-dynamodb-persistence-adapter",
-  "version": "2.11.0",
+  "version": "3.0.0",
   "description": "DynamoDB based implementation package of PersistenceAdapter interface in ASK SDK v2 for Node.js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -29,7 +29,8 @@
     "SDK"
   ],
   "dependencies": {
-    "aws-sdk": "^2.163.0"
+    "@aws-sdk/client-dynamodb": "^3.38.0",
+    "@aws-sdk/lib-dynamodb": "^3.38.0"
   },
   "peerDependencies": {
     "ask-sdk-core": "^2.0.0"
@@ -37,7 +38,7 @@
   "devDependencies": {
     "@types/chai": "^4.1.2",
     "@types/mocha": "^5.0.0",
-    "@types/node": "^9.6.1",
+    "@types/node": "^12.0.0",
     "@typescript-eslint/eslint-plugin": "^3.9.0",
     "@typescript-eslint/parser": "^3.9.0",
     "ask-sdk-core": "^2.11.0",

--- a/ask-sdk-dynamodb-persistence-adapter/tsconfig.json
+++ b/ask-sdk-dynamodb-persistence-adapter/tsconfig.json
@@ -8,9 +8,15 @@
     "sourceMap" : true,
     "alwaysStrict" : true,
     "declaration" : true,
-    "lib": []
+    "lib": [
+      // required for compiling @aws-sdk/*
+      "dom"
+    ]
   },
   "include": [
     "lib"
+  ],
+  "exclude": [
+    "node_modules"
   ]
 }

--- a/ask-sdk-express-adapter/package.json
+++ b/ask-sdk-express-adapter/package.json
@@ -39,7 +39,7 @@
     "@types/chai": "^4.1.2",
     "@types/express": "^4.16.1",
     "@types/mocha": "^5.0.0",
-    "@types/node": "^9.6.1",
+    "@types/node": "^12.0.0",
     "@types/node-forge": "^0.8.0",
     "@types/semver": "^7.3.4",
     "@types/sinon": "^7.0.13",

--- a/ask-sdk-runtime/package.json
+++ b/ask-sdk-runtime/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@types/chai": "^4.1.2",
     "@types/mocha": "^5.0.0",
-    "@types/node": "^9.6.1",
+    "@types/node": "^12.0.0",
     "@types/sinon": "^7.0.13",
     "@typescript-eslint/eslint-plugin": "^3.9.0",
     "@typescript-eslint/parser": "^3.9.0",

--- a/ask-sdk-s3-persistence-adapter/package.json
+++ b/ask-sdk-s3-persistence-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ask-sdk-s3-persistence-adapter",
-  "version": "2.11.0",
+  "version": "3.0.0",
   "description": "S3 based implementation package of PersistenceAdapter interface in ASK SDK v2 for Node.js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -25,7 +25,7 @@
     "SDK"
   ],
   "dependencies": {
-    "aws-sdk": "^2.163.0"
+    "@aws-sdk/client-s3": "^3.38.0"
   },
   "peerDependencies": {
     "ask-sdk-core": "^2.0.0"
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@types/chai": "^4.1.2",
     "@types/mocha": "^5.0.0",
-    "@types/node": "^9.6.1",
+    "@types/node": "^12.0.0",
     "@typescript-eslint/eslint-plugin": "^3.9.0",
     "@typescript-eslint/parser": "^3.9.0",
     "ask-sdk-core": "^2.11.0",

--- a/ask-sdk-s3-persistence-adapter/tsconfig.json
+++ b/ask-sdk-s3-persistence-adapter/tsconfig.json
@@ -8,9 +8,10 @@
     "sourceMap" : true,
     "alwaysStrict" : true,
     "declaration" : true,
-    "lib": []
+    "lib": ["dom"]
   },
   "include": [
     "lib"
-  ]
+  ],
+  "exclude": ["node_modules"]
 }

--- a/ask-sdk-v1adapter/package.json
+++ b/ask-sdk-v1adapter/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@types/chai": "^4.1.2",
     "@types/mocha": "^5.0.0",
-    "@types/node": "^9.6.1",
+    "@types/node": "^12.0.0",
     "@types/sinon": "^7.0.13",
     "@typescript-eslint/eslint-plugin": "^3.9.0",
     "@typescript-eslint/parser": "^3.9.0",

--- a/ask-sdk/package.json
+++ b/ask-sdk/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@types/chai": "^4.1.2",
     "@types/mocha": "^5.0.0",
-    "@types/node": "^9.6.1",
+    "@types/node": "^12.0.0",
     "@typescript-eslint/eslint-plugin": "^3.9.0",
     "@typescript-eslint/parser": "^3.9.0",
     "chai": "^4.1.2",

--- a/ask-smapi-sdk/package.json
+++ b/ask-smapi-sdk/package.json
@@ -27,7 +27,7 @@
     "@types/chai": "^4.1.2",
     "@types/jsonpath": "^0.2.0",
     "@types/mocha": "^5.0.0",
-    "@types/node": "^9.6.1",
+    "@types/node": "^12.0.0",
     "@types/sinon": "^4.3.0",
     "@typescript-eslint/eslint-plugin": "^3.9.0",
     "@typescript-eslint/parser": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"private": true,
 	"scripts": {
+		"postinstall": "lerna bootstrap",
 		"lerna": "./node_modules/.bin/lerna",
 		"setup": "lerna exec npm install",
 		"bootstrap": "lerna bootstrap --force-local --hoist --nohoist=ts-node",


### PR DESCRIPTION
Closes https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/issues/697
Closes https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/issues/696

This change refactors the S3 and DynamoDB persistence adapters to use AWS SDK v3. 

- [ ] As this is a breaking change, I also bumped the major version of those libraries to 3.0.0. Is this correct or should it be a minor version bump?
- [ ] Update the mocked unit tests. See https://www.npmjs.com/package/aws-sdk-client-mock