### PR TITLE
feat: add Interoperability IM to AC handling

### DIFF
--- a/ask-sdk-core/lib/delegation/DelegationData.ts
+++ b/ask-sdk-core/lib/delegation/DelegationData.ts
@@ -1,0 +1,17 @@
+import { Intent, Slot } from "ask-sdk-model";
+
+export interface DelegationData {
+    delegateTarget: DelegateTarget;
+    intentData? : Intent;
+    acirData? : any;
+}
+
+export interface DelegateTarget {
+    type: string;
+    name: string;
+    slots? : {[key : string] : Slot}
+}
+
+export interface SkillToConversationsMapper {
+    delegationMap:Map<string, DelegationData>;
+}

--- a/ask-sdk-core/lib/delegation/DelegationData.ts
+++ b/ask-sdk-core/lib/delegation/DelegationData.ts
@@ -6,8 +6,10 @@ export interface DelegationData {
     acirData? : any;
 }
 
+export declare type target = 'Conversations' | 'Component' | 'Skill';
+
 export interface DelegateTarget {
-    type: string;
+    type: target;
     name: string;
     slots? : {[key : string] : Slot}
 }

--- a/ask-sdk-core/lib/dispatcher/request/handler/DelegateToConversationsHandler.ts
+++ b/ask-sdk-core/lib/dispatcher/request/handler/DelegateToConversationsHandler.ts
@@ -30,7 +30,8 @@ export class DelegateToConversationsHandler implements CustomSkillRequestHandler
         this.skillToConversationsMapper = getSkillToConversationMapper(mapPath);
     }
 
-    private isDelegateToConversationsRequest(requestEnvelope : RequestEnvelope) : boolean {
+    private isDelegateToConversationsRequest(input : HandlerInput) : boolean {
+        const requestEnvelope:RequestEnvelope = input.requestEnvelope;
         if (!this.skillToConversationsMapper ||
             !getDelegationMap(this.skillToConversationsMapper)) {
             return false;
@@ -40,7 +41,7 @@ export class DelegateToConversationsHandler implements CustomSkillRequestHandler
 
     public canHandle(input : HandlerInput) : boolean {
         return getRequestType(input.requestEnvelope) === 'IntentRequest'
-        && this.isDelegateToConversationsRequest(input.requestEnvelope);
+        && this.isDelegateToConversationsRequest(input);
     }
 
     public async handle(input : HandlerInput) : Promise<Response> {

--- a/ask-sdk-core/lib/dispatcher/request/handler/DelegateToConversationsHandler.ts
+++ b/ask-sdk-core/lib/dispatcher/request/handler/DelegateToConversationsHandler.ts
@@ -1,0 +1,94 @@
+
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { RequestEnvelope, Response, dialog, IntentRequest, Slot } from 'ask-sdk-model';
+import { getIntentName, getRequestType } from '../../../util/RequestEnvelopeUtils';
+import { CustomSkillRequestHandler } from './CustomSkillRequestHandler';
+import { HandlerInput } from './HandlerInput';
+import { getDelegateTarget, getDelegateTargetName, getDelegateTargetSlots, getDelegateTargetType, getDelegationMap, getSkillToConversationMapper, getSlotsForComponent, storeIntentSlotsInSession } from '../../../util/DialogInterOperationUtils';
+import { DelegationData, DelegateTarget, SkillToConversationsMapper } from '../../../delegation/DelegationData';
+import DelegateRequestDirective = dialog.DelegateRequestDirective;
+import DelegationPeriod = dialog.DelegationPeriod;
+
+export class DelegateToConversationsHandler implements CustomSkillRequestHandler {
+    private skillToConversationsMapper: SkillToConversationsMapper;
+
+    static readonly defaultMapPath: string = "/var/task/mappings/skillToConversations.json";
+
+    constructor(mapPath: string = DelegateToConversationsHandler.defaultMapPath) {
+        this.skillToConversationsMapper = getSkillToConversationMapper(mapPath);
+    }
+
+    private isDelegateToConversationsRequest(requestEnvelope : RequestEnvelope) : boolean {
+        if (!this.skillToConversationsMapper ||
+            !getDelegationMap(this.skillToConversationsMapper)) {
+            return false;
+        }
+        return getDelegationMap(this.skillToConversationsMapper).has(getIntentName(requestEnvelope));
+    }
+
+    public canHandle(input : HandlerInput) : boolean {
+        return getRequestType(input.requestEnvelope) === 'IntentRequest'
+        && this.isDelegateToConversationsRequest(input.requestEnvelope);
+    }
+
+    public async handle(input : HandlerInput) : Promise<Response> {
+
+        const intentName: string = getIntentName(input.requestEnvelope);
+        const delegationInfo: DelegationData = getDelegationMap(this.skillToConversationsMapper).get(intentName);
+        const delegateTarget:DelegateTarget = getDelegateTarget(delegationInfo);
+
+        const delegationPeriod:DelegationPeriod = {
+            until: 'EXPLICIT_RETURN'
+        };
+
+        if (getDelegateTargetType(delegateTarget) === 'Conversations') {
+            const delegateRequestDirective:DelegateRequestDirective = {
+                type: 'Dialog.DelegateRequest',
+                target: "AMAZON.Conversations",
+                period: delegationPeriod
+            };
+            return input.responseBuilder
+                .addDirective(delegateRequestDirective)
+                .getResponse();
+        }
+
+        storeIntentSlotsInSession(input, intentName);
+
+        const delegateTargetSlots = getDelegateTargetSlots(delegateTarget);
+        const intentSlots = (input.requestEnvelope.request as IntentRequest).intent.slots;
+        const filledSlots: {[key : string] : Slot} = getSlotsForComponent(intentSlots, delegateTargetSlots);
+
+        const dialogInput:dialog.Input = {
+            name: getDelegateTargetName(delegateTarget),
+            slots: filledSlots
+        };
+        
+        const updatedRequest:dialog.UpdatedRequest = {
+            type: 'Dialog.InputRequest',
+            input: dialogInput
+        };
+
+        const delegateRequestDirective:DelegateRequestDirective = {
+            type: 'Dialog.DelegateRequest',
+            target: "AMAZON.Conversations",
+            period: delegationPeriod,
+            updatedRequest
+        };
+
+        return input.responseBuilder
+            .addDirective(delegateRequestDirective)
+            .getResponse();
+    }
+}

--- a/ask-sdk-core/lib/util/DialogInterOperationUtils.ts
+++ b/ask-sdk-core/lib/util/DialogInterOperationUtils.ts
@@ -1,0 +1,62 @@
+import { IntentRequest, Slot } from "ask-sdk-model";
+import { HandlerInput } from "../dispatcher/request/handler/HandlerInput";
+import { DelegateTarget, DelegationData, SkillToConversationsMapper } from "../delegation/DelegationData";
+
+export function getSkillToConversationMapper(mapDir:string):SkillToConversationsMapper {
+    const delegationMap:Map<string, DelegationData> = new Map();
+    const mappings = require(mapDir);
+    Object.keys(mappings.skillToConversations).forEach((intentName) => {
+        const delegationInfo:DelegationData = mappings.skillToConversations[intentName];
+        delegationMap.set(intentName, delegationInfo);
+    });
+    return {
+        delegationMap
+    };
+}
+
+export function getDelegateTarget(delegationInfo : DelegationData) : DelegateTarget {
+    return delegationInfo.delegateTarget;
+}
+
+export function getDelegateTargetType(delegateTarget : DelegateTarget) : string {
+    return delegateTarget.type;
+}
+
+export function getDelegateTargetName(delegateTarget : DelegateTarget) : string {
+    return delegateTarget.name;
+}
+
+export function getDelegateTargetSlots(delegateTarget : DelegateTarget) : {[key : string] : Slot} | undefined {
+    return delegateTarget.slots;
+}
+
+export function getDelegationMap(skillToConversationsMapper: SkillToConversationsMapper)
+    : Map<string, DelegationData> {
+    return skillToConversationsMapper.delegationMap;
+}
+
+export function getSlotsForComponent(intentSlots: {[key : string] : Slot},
+                                     delegateTargetSlots: {[key : string] : Slot} | undefined)
+    : {[key : string] : Slot} {
+    if (!intentSlots || !delegateTargetSlots) {
+        return {};
+    }
+    const filledSlots: {[key : string] : Slot} = {};
+    Object.keys(delegateTargetSlots).forEach((slotKey) => {
+        const slot: Slot | undefined = intentSlots[slotKey];
+        if (slot && slot.value) {
+            filledSlots[slotKey] = slot;
+        }
+    });
+    return filledSlots;
+}
+
+export function storeIntentSlotsInSession(input: HandlerInput, intentName: string) {
+    const sessionAttributes = input.attributesManager.getSessionAttributes();
+    const slots: {[key : string] : Slot} = (input.requestEnvelope.request as IntentRequest).intent.slots;
+    if (!slots) {
+        return;
+    }
+    sessionAttributes[intentName] = slots;
+    input.attributesManager.setSessionAttributes(sessionAttributes);
+}


### PR DESCRIPTION
**This PR is for IM to AC interoperability.**

## Description
This is a request handler which delegates from skill to conversations

## Motivation and Context
Currently a user has to manually delegate from Conversations to Skill and vice versa using Updated request delegate directives as per [https://tiny.amazon.com/18hnuuhhk/deveamazenUSdocsalexconvhand]. It’s a manual effort for skill developer to edit the skill backend to include those directives. 

We want to provide an out-of-box solution to reduce the effort a skill developer has to take for such delegation. The delegation should be automatic (or at-least there should be very less effort for skill dev to utilise our solution)

## Testing
Created a skill which uses the locally built npm module containing the changes

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs(Add new document content)
- [ ] Translate Docs(Translate document content)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License
- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
