### PR TITLE
feat: added component orhcestrator

### DIFF
--- a/ask-sdk-core/lib/components/ComponentOrchestrator.ts
+++ b/ask-sdk-core/lib/components/ComponentOrchestrator.ts
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { Response } from "ask-sdk-model";
+import { HandlerInput } from "../dispatcher/request/handler/HandlerInput";
+import { IMComponentInterface } from "./IMComponentInterface";
+import { GenericComponentOrchestrator } from 'ask-sdk-runtime';
+import { CustomSkillRequestHandler } from "../dispatcher/request/handler/CustomSkillRequestHandler";
+import { getIntentName } from "../util/RequestEnvelopeUtils";
+
+const sessionKey = "componentOrchestrator";
+
+export class ComponentOrchestrator<Input = HandlerInput, Output = Response> implements GenericComponentOrchestrator<Input, Output> {
+
+    // Component Registry Schema -
+    // {
+    //     componentName: {
+    //         insatnceId: ComponentObject
+    //     }
+    // }
+    private _componentRegistry: Record<string, Record<string, IMComponentInterface>>;
+    private _focusState: any[];
+
+    private constructor(componentRegistry: Record<string, Record<string, IMComponentInterface>>, focus: any) {
+        this._componentRegistry = componentRegistry;
+        this._focusState = focus;
+    }
+
+    public static getInstance(handlerInput: HandlerInput): ComponentOrchestrator {
+        const session = handlerInput.attributesManager.getSessionAttributes();
+        const componentOrchestrator = session[sessionKey];
+        // check if the ComponentOrchestrator is inialized using custom skill builder
+        if (componentOrchestrator) {
+            return new ComponentOrchestrator(componentOrchestrator["registry"], componentOrchestrator["focus"]);
+        }
+        else {
+            throw new Error("Component Orchestrator is not being used in the custom skill");
+        }
+
+    }
+
+    public static initialize() {
+        return new ComponentOrchestrator({}, []);
+    }
+
+    registerComponent(component: IMComponentInterface, instanceId: string) {
+        const componentName = component.getName();
+        const registeredComponent = this._componentRegistry[componentName];
+        if (!registeredComponent) {
+            this._componentRegistry[componentName] = {};
+        }
+        else if (registeredComponent[instanceId]) {
+            throw new Error(`${componentName} already registered with instanceId: ${instanceId}`);
+        }
+
+        this._componentRegistry[componentName] = {
+            ...this._componentRegistry[componentName],
+            instanceId: component
+        };
+    }
+
+    egress(componentName: string, input: HandlerInput) {
+        if (this._focusState[0].name !== componentName) {
+            throw new Error(`No component named ${componentName} is currently in focus`);
+        }
+        // remove the component from top of the array
+        this._focusState.shift();
+        this.saveState(input);
+    }
+
+    launch(componentName: string, instanceId: string, input: HandlerInput, launchOptions?: any) {
+        if (!this._componentRegistry[componentName] || !this._componentRegistry[componentName][instanceId]) {
+            throw new Error(`No component registered with component name: ${componentName} and instance id: ${instanceId}`);
+        }
+
+        // insert the component at the start of the array
+        this._focusState.unshift({
+            instanceId,
+            name: componentName
+        });
+        this.saveState(input);
+        this._componentRegistry[componentName][instanceId].launch(launchOptions);
+    }
+
+    serialize(): any {
+        const config = {
+            focus: this._focusState,
+            registry: this._componentRegistry
+        };
+        return config;
+    }
+
+    saveState(input: HandlerInput) {
+        const sessionAttributes = input.attributesManager.getSessionAttributes();
+        sessionAttributes[sessionKey] = this.serialize();
+        input.attributesManager.setSessionAttributes(sessionAttributes);
+    }
+
+    supports(input: Input) {
+        // Check if a component in focus can handle the request
+        if (this._focusState.length > 0) {
+            const componetInFocusMetadata = this._focusState[0];
+            const componetInFocus = this._componentRegistry[componetInFocusMetadata.name][componetInFocusMetadata.instanceId];
+            if (this.componentCanHandle(componetInFocus, input as HandlerInput)) {
+                return true;
+            }
+        }
+
+        // check if any other component has the current intet as the ingress intent.
+        Object.keys(this._componentRegistry).forEach(component => {
+            const key = Object.keys(this._componentRegistry[component])[0];
+            const componentObject = this._componentRegistry[component][key];
+            const intentName = getIntentName((input as HandlerInput).requestEnvelope);
+
+            // check for exact match of intent name
+            if (componentObject.getIngressIntentNames().has(intentName)) {
+                return true;
+            }
+
+            // check if the intent name follows a particular pattern provided by the component
+            componentObject.getIngressIntentPatterns().forEach(pattern => {
+                const regex = RegExp(pattern);
+                if (regex.test(intentName)) {
+                    return true;
+                }
+            });
+        });
+        return false;
+    }
+
+    async execute(input: Input): Promise<Output> {
+        const handlerInput = input as HandlerInput;
+        if (this._focusState.length > 0) {
+            const componetInFocusMetadata = this._focusState[0];
+            const componetInFocus = this._componentRegistry[componetInFocusMetadata.name][componetInFocusMetadata.instanceId];
+            const handler = this.componentCanHandle(componetInFocus, handlerInput);
+            if (handler) {
+                return await handler.handle(handlerInput) as Output;
+            }
+        }
+        else {
+            throw new Error("No component in focus to handle the response");
+        }
+    }
+
+    private componentCanHandle(component: IMComponentInterface, input: HandlerInput): CustomSkillRequestHandler | undefined {
+        component.registerHandlers().forEach(handler => {
+            if (handler.canHandle(input)) {
+                return handler;
+            }
+        });
+        return undefined;
+    }
+}

--- a/ask-sdk-core/lib/components/IMComponentInterface.ts
+++ b/ask-sdk-core/lib/components/IMComponentInterface.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { CustomSkillRequestHandler as RequestHandler } from '../dispatcher/request/handler/CustomSkillRequestHandler';
+import { HandlerInput } from '../dispatcher/request/handler/HandlerInput';
+
+
+export interface IMComponentInterface {
+    getName(): string;
+    getIngressIntentNames(): Set<string>;
+    getIngressIntentPatterns?(): string[];
+    registerHandlers(): RequestHandler[];
+    launch(input: HandlerInput, options?: any): void;
+}

--- a/ask-sdk-core/lib/index.ts
+++ b/ask-sdk-core/lib/index.ts
@@ -78,6 +78,14 @@ export {
 } from './components/ComponentInterface';
 
 export {
+    IMComponentInterface
+} from './components/IMComponentInterface';
+
+export {
+    ComponentOrchestrator
+} from './components/ComponentOrchestrator';
+
+export {
     launchComponent,
     egressFromComponent
 } from './util/ComponentUtils';

--- a/ask-sdk-core/lib/skill/CustomSkillConfiguration.ts
+++ b/ask-sdk-core/lib/skill/CustomSkillConfiguration.ts
@@ -18,6 +18,7 @@ import {
 import { RuntimeConfiguration } from 'ask-sdk-runtime';
 import { PersistenceAdapter } from '../attributes/persistence/PersistenceAdapter';
 import { HandlerInput} from '../dispatcher/request/handler/HandlerInput';
+import { ComponentOrchestrator } from '../components/ComponentOrchestrator';
 
 /**
  * An interfaces that represents the standard components needed to build {@link CustomSkill}.
@@ -27,4 +28,5 @@ export interface CustomSkillConfiguration extends RuntimeConfiguration<HandlerIn
     apiClient? : services.ApiClient;
     customUserAgent? : string;
     skillId? : string;
+    componentOrchestrator? : ComponentOrchestrator;
 }

--- a/ask-sdk-core/lib/skill/factory/BaseSkillFactory.ts
+++ b/ask-sdk-core/lib/skill/factory/BaseSkillFactory.ts
@@ -25,6 +25,7 @@ import { CustomSkillResponseInterceptor } from '../../dispatcher/request/interce
 import { CustomSkill } from '../CustomSkill';
 import { CustomSkillConfiguration } from '../CustomSkillConfiguration';
 import { BaseSkillBuilder } from './BaseSkillBuilder';
+import { ComponentOrchestrator } from '../../components/ComponentOrchestrator';
 
 /**
  * Type definition of LambdaHandler which contains inputs received in lambda function.
@@ -101,6 +102,7 @@ export class BaseSkillFactory {
 
                 return {
                     ...runtimeConfiguration,
+                    componentOrchestrator: ComponentOrchestrator.initialize(),
                     customUserAgent : thisCustomUserAgent,
                     skillId : thisSkillId,
                 };

--- a/ask-sdk-core/lib/skill/factory/CustomSkillBuilder.ts
+++ b/ask-sdk-core/lib/skill/factory/CustomSkillBuilder.ts
@@ -15,6 +15,7 @@ import { services } from 'ask-sdk-model';
 import { PersistenceAdapter } from '../../attributes/persistence/PersistenceAdapter';
 import { BaseSkillBuilder } from './BaseSkillBuilder';
 import ApiClient = services.ApiClient;
+import { ComponentOrchestrator } from '../../components/ComponentOrchestrator';
 
 /**
  * An interface which helps building a customized skill.
@@ -22,4 +23,5 @@ import ApiClient = services.ApiClient;
 export interface CustomSkillBuilder extends BaseSkillBuilder {
     withPersistenceAdapter(persistenceAdapter : PersistenceAdapter) : this;
     withApiClient(apiClient : ApiClient) : this;
+    withComponentOrchestrator(componentOrchestrator: ComponentOrchestrator) : this;
 }

--- a/ask-sdk-core/lib/skill/factory/CustomSkillFactory.ts
+++ b/ask-sdk-core/lib/skill/factory/CustomSkillFactory.ts
@@ -17,6 +17,7 @@ import { CustomSkillConfiguration } from '../CustomSkillConfiguration';
 import { BaseSkillFactory } from './BaseSkillFactory';
 import { CustomSkillBuilder } from './CustomSkillBuilder';
 import ApiClient = services.ApiClient;
+import { ComponentOrchestrator } from '../../components/ComponentOrchestrator';
 
 /**
  * Provider for {@link CustomSkillBuilder}
@@ -25,6 +26,7 @@ export class CustomSkillFactory {
     public static init() : CustomSkillBuilder {
         let thisPersistenceAdapter : PersistenceAdapter;
         let thisApiClient : ApiClient;
+        let thisComponentOrchestrator : ComponentOrchestrator;
 
         const baseSkillBuilder = BaseSkillFactory.init();
 
@@ -37,6 +39,7 @@ export class CustomSkillFactory {
                     ...skillConfiguration,
                     persistenceAdapter : thisPersistenceAdapter,
                     apiClient : thisApiClient,
+                    componentOrchestrator: thisComponentOrchestrator
                 };
             },
             withPersistenceAdapter(persistenceAdapter : PersistenceAdapter) : CustomSkillBuilder {
@@ -49,6 +52,11 @@ export class CustomSkillFactory {
 
                 return this;
             },
+            withComponentOrchestrator(componentOrchestrator: ComponentOrchestrator) : CustomSkillBuilder {
+                thisComponentOrchestrator = componentOrchestrator;
+
+                return this;
+            }
         };
     }
 

--- a/ask-sdk-runtime/lib/dispatcher/request/component-orchestrator/ComponentOrcehstrator.ts
+++ b/ask-sdk-runtime/lib/dispatcher/request/component-orchestrator/ComponentOrcehstrator.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+export interface GenericComponentOrchestrator<Input, Output> {
+
+    supports(input: Input): boolean;
+    execute(input: Input): Promise<Output>;
+}

--- a/ask-sdk-runtime/lib/index.ts
+++ b/ask-sdk-runtime/lib/index.ts
@@ -27,6 +27,7 @@ export { RuntimeConfiguration } from './skill/RuntimeConfiguration';
 export { RuntimeConfigurationBuilder } from './skill/RuntimeConfigurationBuilder';
 export { GenericRequestDispatcher } from './dispatcher/GenericRequestDispatcher';
 export { RequestDispatcher } from './dispatcher/RequestDispatcher';
+export {GenericComponentOrchestrator} from './dispatcher/request/component-orchestrator/ComponentOrcehstrator';
 
 export { Skill } from './skill/Skill';
 

--- a/ask-sdk-runtime/lib/skill/RuntimeConfiguration.ts
+++ b/ask-sdk-runtime/lib/skill/RuntimeConfiguration.ts
@@ -12,6 +12,7 @@
  */
 
 import { ErrorMapper } from '../dispatcher/error/mapper/ErrorMapper';
+import { GenericComponentOrchestrator } from '../dispatcher/request/component-orchestrator/ComponentOrcehstrator';
 import { HandlerAdapter } from '../dispatcher/request/handler/HandlerAdapter';
 import { RequestInterceptor } from '../dispatcher/request/interceptor/RequestInterceptor';
 import { ResponseInterceptor } from '../dispatcher/request/interceptor/ResponseInterceptor';
@@ -23,4 +24,5 @@ export interface RuntimeConfiguration<Input, Output> {
     errorMapper? : ErrorMapper<Input, Output>;
     requestInterceptors? : Array<RequestInterceptor<Input>>;
     responseInterceptors? : Array<ResponseInterceptor<Input, Output>>;
+    componentOrchestrator? : GenericComponentOrchestrator<Input, Output>;
 }


### PR DESCRIPTION
## Description
Added component orchestrator feature to register skill components and manage them on runtime.

## Motivation and Context
When consuming components in a IM skill there is a very possible chance of having conflicts of utterances which can be handled by the component or by the skill or by multiple components at the same time. For example a simple intent like `YesIntent` can be used by a skill developer on of their own multi turn skill experience and the same intent can also be used by a component like Catalog Explorer when providing some hint to the user and expecting user to say yes to the request. 

The component orchestrator solves this problem by managing the focus state of components and a registry of all the components registered in the skill.

## Testing
Created a test component with some utterances conflicting with the handlers registered for the skill as well. The component orchestrator was able to route the request to suitable handler based on the situation. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs(Add new document content)
- [ ] Translate Docs(Translate document content)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License
- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.